### PR TITLE
Authorized API Server IP Ranges

### DIFF
--- a/05-aks-cluster.md
+++ b/05-aks-cluster.md
@@ -23,7 +23,8 @@ Now that the [hub-spoke network is provisioned](./04-networking.md), the next st
    TARGET_VNET_RESOURCE_ID=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0008 --query properties.outputs.clusterVnetResourceId.value -o tsv)
    ```
 
-1. Deploy the cluster ARM template.
+1. Deploy the cluster ARM template.  
+  It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter. By default, it has full access by all ips.
 
    **Option 1 - Deploy in the Azure Portal**
 
@@ -32,8 +33,6 @@ Now that the [hub-spoke network is provisioned](./04-networking.md), the next st
    [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmspnp%2Faks-secure-baseline%2Fmain%2Fcluster-stamp.json)
 
     **Option 2 - Deploy from the command line**
-      It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter.
-
    ```bash
    # [This takes about 15 minutes.]
    az deployment group create --resource-group rg-bu0001a0008 --template-file cluster-stamp.json --parameters targetVnetResourceId=$TARGET_VNET_RESOURCE_ID k8sRbacAadProfileAdminGroupObjectID=$K8S_RBAC_AAD_PROFILE_ADMIN_GROUP_OBJECTID k8sRbacAadProfileTenantId=$K8S_RBAC_AAD_PROFILE_TENANTID appGatewayListenerCertificate=$APP_GATEWAY_LISTENER_CERTIFICATE

--- a/05-aks-cluster.md
+++ b/05-aks-cluster.md
@@ -24,7 +24,7 @@ Now that the [hub-spoke network is provisioned](./04-networking.md), the next st
    ```
 
 1. Deploy the cluster ARM template.  
-  It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter. By default, it has full access by all ips.
+  :exclamation: By default, this deployment will allow unrestricted access to your cluster's API Server.  You can limit access to the API Server to a set of well-known IP addresses (i.,e. your hub firewall IP, bastion subnet, build agents, or any other networks you'll administer the cluster from) by setting the `clusterAuthorizedIPRanges` parameter in all deployment options.  
 
    **Option 1 - Deploy in the Azure Portal**
 

--- a/05-aks-cluster.md
+++ b/05-aks-cluster.md
@@ -32,6 +32,7 @@ Now that the [hub-spoke network is provisioned](./04-networking.md), the next st
    [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmspnp%2Faks-secure-baseline%2Fmain%2Fcluster-stamp.json)
 
     **Option 2 - Deploy from the command line**
+      It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter.
 
    ```bash
    # [This takes about 15 minutes.]

--- a/azuredeploy.parameters.prod.json
+++ b/azuredeploy.parameters.prod.json
@@ -21,7 +21,7 @@
       "value": "[base64 cert data]"
     },
     "clusterAuthorizedIPRanges": {
-      "value": "[array of ip ranges, like ['168.196.25.0/24','73.140.245.0/28'] ]"
+      "value": "[array of IP ranges, like ['168.196.25.0/24','73.140.245.0/28', AzureFirewallIP/32] ]"
     }
   }
 }

--- a/azuredeploy.parameters.prod.json
+++ b/azuredeploy.parameters.prod.json
@@ -19,6 +19,9 @@
     },
     "appGatewayListenerCertificate": {
       "value": "[base64 cert data]"
+    },
+    "clusterAuthorizedIPRanges": {
+      "value": "[array of ip ranges, like ['168.196.25.0/24','73.140.245.0/28'] ]"
     }
   }
 }

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -30,7 +30,7 @@
             "type": "array",
             "defaultValue": [],
             "metadata": {
-                "description": "Authorized IP Ranges to kubernetes API server. Passing an empty array it will result in a full access by all ips"
+                "description": "IP ranges authorized to contact the Kubernetes API server. Passing an empty array will result in no IP restrictions. If any are provided, remember to also provide the public IP of the egress Azure Firewall otherwise your nodes will not be able to talk to the API server (e.g. Flux)."
             }
         },
         "location": {

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -26,6 +26,13 @@
                 "description": "The certificate data for app gateway TLS termination. It is base64"
             }
         },
+        "clusterAuthorizedIPRanges": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Authorized IP Ranges to kubernetes API server. Passing an empty array it will result in a full access by all ips"
+            }
+        },
         "location": {
             "defaultValue": "eastus2",
             "type": "string",
@@ -71,7 +78,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.17.5",
+            "defaultValue": "1.17.7",
             "type": "string"
         }
     },
@@ -823,6 +830,7 @@
                     "max-graceful-termination-sec": "600"
                 },
                 "apiServerAccessProfile": {
+                    "authorizedIPRanges": "[parameters('clusterAuthorizedIPRanges')]",
                     "enablePrivateCluster": false
                 }
             },

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -52,7 +52,7 @@ env:
   TARGET_VNET_RESOURCE_ID: '<cluster-spoke-vnet-resource-id>'                       # The regional network spoke VNet Resource ID that the cluster will be joined to
   K8S_RBAC_AAD_PROFILE_TENANTID: '<tenant-id-with-user-admin-permissions>'          # The tenant to integrate AKS-managed Azure AD
   K8S_RBAC_AAD_PROFILE_ADMIN_GROUP_OBJECTID: '<azure-ad-aks-admin-group-object-id>' # The Azure AD group object ID that has admin access to the AKS cluster
-
+  CLUSTER_AUTHORIZED_IP_RANGES: '[]'                                                # By default, this deployment will allow unrestricted access to your cluster's API Server. You should limit access to the API Server to a set of well-known IP addresses (i.,e. your hub firewall IP, bastion subnet, build agents, or any other networks you'll administer the cluster from), and can do so by adding a CLUSTER_AUTHORIZED_IP_RANGES="['managementRange1', 'managementRange2', 'AzureFirewallIP/32']"" parameter. 
 jobs:
   deploy:
     name: Deploy AKS cluster and Flux
@@ -85,6 +85,7 @@ jobs:
               k8sRbacAadProfileTenantId=${{ env.K8S_RBAC_AAD_PROFILE_TENANTID }} \
               k8sRbacAadProfileAdminGroupObjectID=${{ env.K8S_RBAC_AAD_PROFILE_ADMIN_GROUP_OBJECTID }} \
               appGatewayListenerCertificate=${{ secrets.APP_GATEWAY_LISTENER_CERTIFICATE_BASE64 }}
+              clusterAuthorizedIPRanges=${{ secrets.CLUSTER_AUTHORIZED_IP_RANGES}}
 
           echo "::set-output name=name::$(az deployment group show --resource-group ${{ env.RESOURCE_GROUP }} -n cluster-stamp-cd --query properties.outputs.aksClusterName.value -o tsv)"
         azcliversion: 2.6.0

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -68,6 +68,7 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     # Deploy the cluster into your environment, assuming all prerequisites are up and running.
+    # It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter. By default, full access by all ips.
     - name: Azure CLI - Deploy AKS cluster
       id: aks-cluster
       uses: Azure/cli@v1.0.0

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -68,7 +68,6 @@ jobs:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     # Deploy the cluster into your environment, assuming all prerequisites are up and running.
-    # It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter. By default, full access by all ips.
     - name: Azure CLI - Deploy AKS cluster
       id: aks-cluster
       uses: Azure/cli@v1.0.0

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -84,8 +84,8 @@ jobs:
               targetVnetResourceId=${{ env.TARGET_VNET_RESOURCE_ID }} \
               k8sRbacAadProfileTenantId=${{ env.K8S_RBAC_AAD_PROFILE_TENANTID }} \
               k8sRbacAadProfileAdminGroupObjectID=${{ env.K8S_RBAC_AAD_PROFILE_ADMIN_GROUP_OBJECTID }} \
-              appGatewayListenerCertificate=${{ secrets.APP_GATEWAY_LISTENER_CERTIFICATE_BASE64 }}
-              clusterAuthorizedIPRanges=${{ secrets.CLUSTER_AUTHORIZED_IP_RANGES}}
+              appGatewayListenerCertificate=${{ secrets.APP_GATEWAY_LISTENER_CERTIFICATE_BASE64 }} \
+              clusterAuthorizedIPRanges=${{ env.CLUSTER_AUTHORIZED_IP_RANGES}}
 
           echo "::set-output name=name::$(az deployment group show --resource-group ${{ env.RESOURCE_GROUP }} -n cluster-stamp-cd --query properties.outputs.aksClusterName.value -o tsv)"
         azcliversion: 2.6.0

--- a/inner-loop-scripts/shell/1-cluster-stamp.sh
+++ b/inner-loop-scripts/shell/1-cluster-stamp.sh
@@ -33,7 +33,8 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 openssl pkcs12 -export -out appgw.pfx -in appgw.crt -inkey appgw.key -passout pass:
 APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 -w 0)
 
-#AKS Cluster Creation. Advance Networking. AAD identity integration. This might take about 10 minutes
+# AKS Cluster Creation. Advance Networking. AAD identity integration. This might take about 10 minutes
+# It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter. By default, full access by all ips.
 az deployment group create --resource-group "${RGNAMECLUSTER}" --template-file "../../cluster-stamp.json" --name "cluster-0001" --parameters \
                location=$LOCATION \
                geoRedundancyLocation=$GEOREDUNDANCY_LOCATION \

--- a/inner-loop-scripts/shell/1-cluster-stamp.sh
+++ b/inner-loop-scripts/shell/1-cluster-stamp.sh
@@ -34,7 +34,9 @@ openssl pkcs12 -export -out appgw.pfx -in appgw.crt -inkey appgw.key -passout pa
 APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 -w 0)
 
 # AKS Cluster Creation. Advance Networking. AAD identity integration. This might take about 10 minutes
-# It is possible to restrict the ips, from where the kubernetes API server is accessed, by setting the clusterAuthorizedIPRanges parameter. By default, full access by all ips.
+# Note: By default, this deployment will allow unrestricted access to your cluster's API Server. 
+#   You should limit access to the API Server to a set of well-known IP addresses (i.,e. your hub firewall IP, bastion subnet, build agents, or any other networks you'll administer the cluster from), 
+#   and can do so by adding a `clusterAuthorizedIPRanges=['range1', 'range2', 'AzureFirewallIP/32']` parameter below.
 az deployment group create --resource-group "${RGNAMECLUSTER}" --template-file "../../cluster-stamp.json" --name "cluster-0001" --parameters \
                location=$LOCATION \
                geoRedundancyLocation=$GEOREDUNDANCY_LOCATION \


### PR DESCRIPTION
ARM template to support the concept of authorized IP ranges for the API server.  
We start that parameter out defaulted to "empty" (allow all). 
Readme, it is  mentioned that you have the ability to restrict it.

https://docs.microsoft.com/en-us/azure/templates/microsoft.containerservice/managedclusters
authorizedIPRanges

https://docs.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges

https://docs.microsoft.com/en-us/cli/azure/ext/aks-preview/aks?view=azure-cli-latest#ext-aks-preview-az-aks-create