### PR TITLE
[FCP] [AAC-AKS] [Fix] Assign Azure Policies V2 to AKS (#1) 

### DIFF
--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -38,6 +38,25 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops), wrapping 
    kubectl get constrainttemplate
    ```
 
+   A similar output as the one showed below should be returned
+
+   ```bash
+   NAME                                     AGE
+   k8sazureallowedcapabilities              75m
+   k8sazureallowedseccomp                   75m
+   k8sazureallowedusersgroups               75m
+   k8sazureblockhostnamespace               75m
+   k8sazurecontainerallowedimages           75m
+   k8sazurecontainerlimits                  75m
+   k8sazurecontainernoprivilege             75m
+   k8sazurecontainernoprivilegeescalation   75m
+   k8sazurehostnetworkingports              75m
+   k8sazureingresshttpsonly                 75m
+   k8sazureloadbalancernopublicips          75m
+   k8sazurereadonlyrootfilesystem           75m
+   k8sazurevolumetypes                      75m
+   ```
+
 ### Next step
 
 :arrow_forward: [Configure AKS Ingress Controller with Azure Key Vault integration](./08-secret-managment-and-ingress-controller.md)

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -819,7 +819,7 @@
                     "aciConnectorLinux": {
                         "enabled": false
                     },
-                    "azurePolicy": {
+                    "azurepolicy": {
                         "enabled": true,
                         "config": {
                             "version": "v2"


### PR DESCRIPTION
the azure policy pre-existent field was case sensitive for Azure Policy V2 causing a duplicate add on profile entry and as consequence the  Azure Policy for Kubernetes wasn't getting deployed into the AKS cluster

Hightlights

  - change case from the azure policy add on profile field
  - improve validation to know what to expect

solves: #18