### PR TITLE
delete AAD-V2 feature registration

### DIFF
--- a/01-prerequisites.md
+++ b/01-prerequisites.md
@@ -18,7 +18,6 @@ This is the starting point for the instructions on deploying the [AKS Secure Bas
 
    [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
 1. While the following features are still in _preview_, please enable them manually in your subscription.
-   1. [Register the AAD-V2 feature for AKS-managed Azure AD](https://docs.microsoft.com/azure/aks/managed-aad#before-you-begin).
    1. [Register the required Azure Policy features for AKS](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/policy-for-kubernetes#install-azure-policy-add-on-for-aks).
 1. Clone/download this repo locally, or even better fork this repository.
 


### PR DESCRIPTION
closes: #16 

since AAD V2 is now officially GA, we can remove the pre-req to register this as a feature.