### PR TITLE
Param ordering - Workload Prereqs

### DIFF
--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -14,7 +14,7 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops), wrapping 
 
    ```bash
    KEYVAULT_NAME=$(az deployment group show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.keyVaultName.value -o tsv)
-   az keyvault set-policy --certificate-permissions import list get -n $KEYVAULT_NAME --upn $(az account show --query user.name -o tsv)
+   az keyvault set-policy --certificate-permissions import list get --upn $(az account show --query user.name -o tsv) -n $KEYVAULT_NAME
    ```
 
 1. Import the AKS Ingress Controller's Wildcard Certificate for `*.aks-ingress.contoso.com`.
@@ -25,7 +25,7 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops), wrapping 
 
    ```bash
    cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt traefik-ingress-internal-aks-ingress-contoso-com-tls.key > traefik-ingress-internal-aks-ingress-contoso-com-tls.pem
-   az keyvault certificate import --vault-name $KEYVAULT_NAME -f traefik-ingress-internal-aks-ingress-contoso-com-tls.pem -n traefik-ingress-internal-aks-ingress-contoso-com-tls
+   az keyvault certificate import -f traefik-ingress-internal-aks-ingress-contoso-com-tls.pem -n traefik-ingress-internal-aks-ingress-contoso-com-tls --vault-name $KEYVAULT_NAME
    ```
 
 ## Check Azure Policies are in place


### PR DESCRIPTION
Just moving the "variable" bit of the CLI command to the end to make it easier for those walking through that might not be using the output variables and instead copy and pasting + editing the command.