### PR TITLE
Update Log Analytics resource name for hub-spoke network to be unique

### DIFF
--- a/networking/hub-default.json
+++ b/networking/hub-default.json
@@ -61,7 +61,7 @@
         "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default')]",
         "hubFwName": "[concat('fw-', parameters('location'), '-hub')]",
         "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'))]"
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-',uniqueString(resourceId('Microsoft.Network/virtualNetworks',variables('hubVnetName'))))]"
     },
     "resources": [
         {

--- a/networking/hub-regionA.json
+++ b/networking/hub-regionA.json
@@ -69,7 +69,7 @@
         "defaultFwPipName": "[concat('pip-fw-', parameters('location'), '-default')]",
         "hubFwName": "[concat('fw-', parameters('location'), '-hub')]",
         "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
-        "hubLaName": "[concat('la-networking-hub-', parameters('location'))]"
+        "hubLaName": "[concat('la-networking-hub-', parameters('location'),'-',uniqueString(resourceId('Microsoft.Network/virtualNetworks',variables('hubVnetName'))))]"
     },
     "resources": [
         {

--- a/networking/spoke-BU0001A0008.json
+++ b/networking/spoke-BU0001A0008.json
@@ -129,7 +129,7 @@
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]"
             ],
             "properties": {
-                "workspaceId": "[resourceId(variables('hubRgName'), 'Microsoft.OperationalInsights/workspaces', concat('la-networking-hub-', reference(parameters('hubVnetResourceId'), '2019-11-01', 'Full').location))]",
+                "workspaceId": "[resourceId(variables('hubRgName'), 'Microsoft.OperationalInsights/workspaces', concat('la-networking-hub-', reference(parameters('hubVnetResourceId'), '2019-11-01', 'Full').location,'-',uniqueString(parameters('hubVnetResourceId'))))]",
                 "metrics": [
                     {
                         "category": "AllMetrics",


### PR DESCRIPTION
Closes: #14

Change definition of name for Log Analytics Workspace for the Hub-Spoke
network to include a uniqueString based on the resourceId of the hub
VNET.  The resourceId includes the subscription id as well as the
resource group of the hub network so this will allow multiple
deployments within the same subscription if different resource groups
are used.