### PR TITLE
Update policy limits to use proper units

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1070,10 +1070,10 @@
               "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e345eecc-fa47-480f-9e88-67dcc122b164",
               "parameters": {
                 "cpuLimit": {
-                  "value": "1000"
+                  "value": "1000m"
                 },
                 "memoryLimit": {
-                  "value": "512"
+                  "value": "512Mi"
                 },
                 "excludedNamespaces": {
                   "value": [


### PR DESCRIPTION
Policy was blocking the creation of containers that exceeded 512 bytes of memory.  Updating memoryLimit and cpuLimit to use proper units (see: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes). 512Mi is 512 Megabytes (base-2, Mebibytes).  1000m is 1000 millicores, or 1 core.
Closes: #42