### PR TITLE
Update validation step to use a container image from the allowlist

### DIFF
--- a/09-workload.md
+++ b/09-workload.md
@@ -33,9 +33,7 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
 1. Give a try and expect a `403` HTTP response
 
    ```bash
-   kubectl -n a0008 run -i --rm --tty curl --image=curlimages/curl -- sh
-   curl --insecure -k -I --resolve bu0001a0008-00.aks-ingress.contoso.com:443:10.240.4.4 https://bu0001a0008-00.aks-ingress.contoso.com
-   exit 0
+   kubectl -n a0008 run -i --rm --tty curl --image=mcr.microsoft.com/powershell --limits=cpu=200m,memory=128M -- curl -kI https://bu0001a0008-00.aks-ingress.contoso.com -w '%{remote_ip}\n'
    ```
 
 ### Next step


### PR DESCRIPTION
The image curlimage/curl was not allowed by the policy at https://github.com/mspnp/aks-secure-baseline/blob/256b2bb/cluster-stamp.json#L1101 Switching this validation step to use the MCR hosted PowerShell image.  This image has curl available as well.