### PR TITLE
add a -o tsv flag to the K8S_RBAC_AAD_PROFILE_TENANT_DOMAIN_NAME

### DIFF
--- a/03-aad.md
+++ b/03-aad.md
@@ -30,7 +30,7 @@ In the prior step, you [generated the user-facing TLS certificate](./02-ca-certi
    > :book: The organization knows the value of having a break-glass admin user for their critical infrastructure. The app team requests a cluster admin user and Azure AD Admin team proceeds with the creation of the user from Azure AD.
 
    ```bash
-   K8S_RBAC_AAD_PROFILE_TENANT_DOMAIN_NAME=$(az ad signed-in-user show --query 'userPrincipalName' | cut -d '@' -f 2 | sed 's/\"//')
+   K8S_RBAC_AAD_PROFILE_TENANT_DOMAIN_NAME=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv | cut -d '@' -f 2 | sed 's/\"//')
    AKS_ADMIN_OBJECTID=$(az ad user create --display-name=bu0001a0008-admin --user-principal-name bu0001a0008-admin@${K8S_RBAC_AAD_PROFILE_TENANT_DOMAIN_NAME} --force-change-password-next-login --password ChangeMebu0001a0008AdminChangeMe --query objectId -o tsv)
    ```
 


### PR DESCRIPTION
force `-o tsv` to the output of K8S_RBAC_AAD_PROFILE_TENANT_DOMAIN_NAME otherwise the sed regex will fail for anyone with a different output format (e.g.: table). 