### PR TITLE
Update base64 command instructions to use tr

### DIFF
--- a/02-ca-certificates.md
+++ b/02-ca-certificates.md
@@ -22,7 +22,7 @@ Now that you have the [prerequisites](./01-prerequisites.md) met, follow the ste
    :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the certificate (as `.pfx`) to be base 64 encoded for proper storage in Key Vault later.
 
    ```bash
-   export APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 -w 0)
+   export APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 | tr -d '\n')
    ```
 
 1. Generate the wildcard certificate for the AKS Ingress Controller
@@ -38,7 +38,7 @@ Now that you have the [prerequisites](./01-prerequisites.md) met, follow the ste
    :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the public certificate (as `.crt` or `.cer`) to be base 64 encoded for proper storage in Key Vault later.
 
    ```bash
-   export AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 -w 0)
+   export AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 | tr -d '\n')
    ```
 
 ### Next step

--- a/index.html
+++ b/index.html
@@ -379,7 +379,7 @@ layout: false
    Note: No matter if you used a certificate from your organization or you generated one from above, you'll need the certificate (as `.pfx`) to be base 64 encoded for proper storage in Key Vault later.
 
    ```bash
-   export APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 -w 0)
+   export APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 | tr -d '\n')
    ```
 
 3\. Generate the wildcard certificate for the AKS Ingress Controller
@@ -405,7 +405,7 @@ layout: false
    Note: No matter if you used a certificate from your organization or you generated one from above, you'll need the public certificate (as `.crt` or `.cer`) to be base 64 encoded for proper storage in Key Vault later.
 
    ```bash
-   export AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 -w 0)
+   export AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 | tr -d '\n')
    ```
 ]
 ---

--- a/inner-loop-scripts/shell/1-cluster-stamp.sh
+++ b/inner-loop-scripts/shell/1-cluster-stamp.sh
@@ -34,14 +34,14 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
         -keyout appgw.key \
         -subj "/CN=bicycle.contoso.com/O=Contoso Bicycle"
 openssl pkcs12 -export -out appgw.pfx -in appgw.crt -inkey appgw.key -passout pass:
-APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 -w 0)
+APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 | tr -d '\n')
 
 # AKS Ingress Controller Certificate
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
         -out traefik-ingress-internal-aks-ingress-contoso-com-tls.crt \
         -keyout traefik-ingress-internal-aks-ingress-contoso-com-tls.key \
         -subj "/CN=*.aks-ingress.contoso.com/O=Contoso Aks Ingress"
-AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 -w 0)
+AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 | tr -d '\n')
 
 # AKS Cluster Creation. Advance Networking. AAD identity integration. This might take about 10 minutes
 # Note: By default, this deployment will allow unrestricted access to your cluster's API Server.


### PR DESCRIPTION
Update base64 command instructions to use tr to be more compatible with MacOS and GNU versions of the command.

Fixes: #62