### PR TITLE
put PDB into the correct namespace and use full label

### DIFF
--- a/workload/aspnetapp.yaml
+++ b/workload/aspnetapp.yaml
@@ -75,11 +75,12 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: aspnetapp-pdb
+  namespace: a0008
 spec:
   minAvailable: 75%
   selector:
     matchLabels:
-      app: aspnetapp
+      app.kubernetes.io/name: aspnetapp
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
PDB wasn't being applied to the aspnetapp workload as expected, wasn't in the right namespace and the label didn't match anything.

Fixes #47 