### PR TITLE
Update to latest CSI Secret Store Key Vault bits

### DIFF
--- a/06-gitops.md
+++ b/06-gitops.md
@@ -67,8 +67,8 @@ GitOps allows a team to author Kubernetes manifest files, persist them in their 
    az acr import --source docker.io/fluxcd/flux:1.19.0 -n $ACR_NAME
    az acr import --source docker.io/weaveworks/kured:1.4.0 -n $ACR_NAME
    az acr import --source quay.io/k8scsi/csi-node-driver-registrar:v1.2.0 -n $ACR_NAME
-   az acr import --source docker.io/deislabs/secrets-store-csi:v0.0.11 -n $ACR_NAME
-   az acr import --source quay.io/k8scsi/livenessprobe:v1.1.0 -n $ACR_NAME
+   az acr import --source us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16 -n $ACR_NAME
+   az acr import --source quay.io/k8scsi/livenessprobe:v2.0.0 -n $ACR_NAME
    ```
 
 1. Deploy Flux.

--- a/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
+++ b/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
@@ -247,7 +247,7 @@ spec:
               cpu: 100m
               memory: 256Mi
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         agentpool: npuser01
 ---
 apiVersion: apps/v1
@@ -316,5 +316,5 @@ spec:
         hostPath:
           path: /etc/kubernetes/azure.json
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         agentpool: npuser01

--- a/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -10,11 +10,27 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: secretproviderclasses-role
   labels:
     app.kubernetes.io/name: secrets-store-csi-driver
     app.kubernetes.io/component: csi-driver
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
@@ -22,23 +38,26 @@ rules:
   verbs:
   - get
   - list
-  - update
+  - watch
 - apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
-  - secretproviderclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
+  - secretproviderclasspodstatuses
   verbs:
   - create
   - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses/status
+  verbs:
+  - get
+  - patch
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,11 +89,12 @@ spec:
   volumeLifecycleModes:
   - Ephemeral
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: secretproviderclasses.secrets-store.csi.x-k8s.io
   labels:
@@ -88,82 +108,157 @@ spec:
     plural: secretproviderclasses
     singular: secretproviderclass
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: SecretProviderClass is the Schema for the secretproviderclasses
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SecretProviderClassSpec defines the desired state of SecretProviderClass
-          properties:
-            parameters:
-              additionalProperties:
-                type: string
-              description: Configuration for specific provider
-              type: object
-            provider:
-              description: Configuration for provider name
-              type: string
-            secretObjects:
-              items:
-                description: SecretObject defines the desired state of synced K8s
-                  secret objects
-                properties:
-                  data:
-                    items:
-                      description: SecretObjectData defines the desired state of synced
-                        K8s secret object data
-                      properties:
-                        key:
-                          description: data field to populate
-                          type: string
-                        objectName:
-                          description: name of the object to sync
-                          type: string
-                      type: object
-                    type: array
-                  secretName:
-                    description: name of the K8s secret object
-                    type: string
-                  type:
-                    description: type of K8s secret object
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: SecretProviderClassStatus defines the observed state of SecretProviderClass
-          properties:
-            byPod:
-              items:
-                description: ByPodStatus defines the state of SecretProviderClass
-                  as seen by an individual controller
-                properties:
-                  id:
-                    description: id of the pod that wrote the status
-                    type: string
-                  namespace:
-                    description: namespace of the pod that wrote the status
-                    type: string
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecretProviderClass is the Schema for the secretproviderclasses
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SecretProviderClassSpec defines the desired state of SecretProviderClass
+            properties:
+              parameters:
+                additionalProperties:
+                  type: string
+                description: Configuration for specific provider
+                type: object
+              provider:
+                description: Configuration for provider name
+                type: string
+              secretObjects:
+                items:
+                  description: SecretObject defines the desired state of synced K8s
+                    secret objects
+                  properties:
+                    data:
+                      items:
+                        description: SecretObjectData defines the desired state of
+                          synced K8s secret object data
+                        properties:
+                          key:
+                            description: data field to populate
+                            type: string
+                          objectName:
+                            description: name of the object to sync
+                            type: string
+                        type: object
+                      type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: labels of K8s secret object
+                      type: object
+                    secretName:
+                      description: name of the K8s secret object
+                      type: string
+                    type:
+                      description: type of K8s secret object
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: SecretProviderClassStatus defines the observed state of SecretProviderClass
+            properties:
+              byPod:
+                items:
+                  description: ByPodStatus defines the state of SecretProviderClass
+                    as seen by an individual controller
+                  properties:
+                    id:
+                      description: id of the pod that wrote the status
+                      type: string
+                    namespace:
+                      description: namespace of the pod that wrote the status
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver-secretproviderclasspodstatuses-crd
+    app.kubernetes.io/component: csi-driver
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClassPodStatus
+    listKind: SecretProviderClassPodStatusList
+    plural: secretproviderclasspodstatuses
+    singular: secretproviderclasspodstatus
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: SecretProviderClassPodStatusStatus defines the observed state
+              of SecretProviderClassPodStatus
+            properties:
+              mounted:
+                type: boolean
+              objects:
+                items:
+                  description: SecretProviderClassObject defines the object fetched
+                    from external secrets store
+                  properties:
+                    id:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+              podName:
+                type: string
+              secretProviderClassName:
+                type: string
+              targetPath:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 status:
@@ -194,7 +289,7 @@ spec:
         app.kubernetes.io/component: csi-driver
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         agentpool: npuser01
       serviceAccountName: secrets-store-csi-driver
       hostNetwork: true
@@ -203,9 +298,9 @@ spec:
           # PRODUCTION READINESS CHANGE REQUIRED
           # This image should be sourced from a non-public container registry, such as the
           # one deployed along side of this reference implementation.
-          # az acr import --source docker.io/weaveworks/kured:1.4.0 -n <your-acr-instance-name>
+          # az acr import --source quay.io/k8scsi/csi-node-driver-registrar:v1.2.0 -n <your-acr-instance-name>
           # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/weaveworks/kured:1.4.0
+          # image: <your-acr-instance-name>.azurecr.io/k8scsi/csi-node-driver-registrar:v1.2.0
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - --v=5
@@ -232,19 +327,30 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         - name: secrets-store
           # PRODUCTION READINESS CHANGE REQUIRED
           # This image should be sourced from a non-public container registry, such as the
           # one deployed along side of this reference implementation.
-          # az acr import --source docker.io/deislabs/secrets-store-csi:v0.0.11 -n <your-acr-instance-name>
+          # az acr import --source us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16 -n <your-acr-instance-name>
           # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/deislabs/secrets-store-csi:v0.0.11
-          image: docker.io/deislabs/secrets-store-csi:v0.0.11
+          # image: <your-acr-instance-name>.azurecr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16
+          image: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16
           args:
             - "--debug=false"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
+            - "--metrics-addr=:8095"
+            - "--enable-secret-rotation=false" # To use this alpha feature, follow guidance at https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/docs/README.rotation.md
+            - "--rotation-poll-interval=5m"
+            - "--grpc-supported-providers=azure"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -276,22 +382,37 @@ spec:
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
         - name: liveness-probe
           # PRODUCTION READINESS CHANGE REQUIRED
           # This image should be sourced from a non-public container registry, such as the
           # one deployed along side of this reference implementation.
-          # az acr import --source quay.io/k8scsi/livenessprobe:v1.1.0 -n <your-acr-instance-name>
+          # az acr import --source quay.io/k8scsi/livenessprobe:v2.0.0 -n <your-acr-instance-name>
           # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/k8scsi/livenessprobe:v1.1.0
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          # image: <your-acr-instance-name>.azurecr.io/k8scsi/livenessprobe:v2.0.0
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
           imagePullPolicy: Always
           args:
           - --csi-address=/csi/csi.sock
           - --probe-timeout=3s
           - --health-port=9808
+          - -v=2
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
       volumes:
         - name: mountpoint-dir
           hostPath:
@@ -309,6 +430,49 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretprovidersyncing-role
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretprovidersyncing-rolebinding
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretprovidersyncing-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -332,10 +496,19 @@ spec:
         app.kubernetes.io/name: csi-secrets-store-provider-azure
         app.kubernetes.io/component: csi-provider
     spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      hostNetwork: true
       containers:
         - name: provider-azure-installer
-          image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.6
-          imagePullPolicy: Always
+          image: mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.9
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=unix:///provider/azure.sock
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "rm /provider/azure.sock"
           resources:
             requests:
               cpu: 50m
@@ -343,16 +516,21 @@ spec:
             limits:
               cpu: 50m
               memory: 100Mi
-          env:
-            - name: TARGET_DIR
-              value: "/etc/kubernetes/secrets-store-csi-providers"
           volumeMounts:
-            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+            - mountPath: "/provider"
               name: providervol
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+          securityContext:
+            privileged: true
       volumes:
         - name: providervol
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         agentpool: npuser01

--- a/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -121,7 +121,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: cluster-baseline-settings
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver

--- a/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -473,6 +473,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-secrets-store-provider-azure
+  namespace: cluster-baseline-settings
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -7,6 +7,15 @@ metadata:
     app.kubernetes.io/name: secrets-store-csi-driver
     app.kubernetes.io/component: csi-driver
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: cluster-baseline-settings
+  labels:
+    app.kubernetes.io/name: csi-secrets-store-provider-azure
+    app.kubernetes.io/component: csi-provider
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -76,6 +85,44 @@ subjects:
   name: secrets-store-csi-driver
   namespace: cluster-baseline-settings
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretprovidersyncing-role
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretprovidersyncing-rolebinding
+  labels:
+    app.kubernetes.io/name: secrets-store-csi-driver
+    app.kubernetes.io/component: csi-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretprovidersyncing-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default
+---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
@@ -89,7 +136,6 @@ spec:
   volumeLifecycleModes:
   - Ephemeral
 ---
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -430,50 +476,6 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: secretprovidersyncing-role
-  labels:
-    app.kubernetes.io/name: secrets-store-csi-driver
-    app.kubernetes.io/component: csi-driver
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: secretprovidersyncing-rolebinding
-  labels:
-    app.kubernetes.io/name: secrets-store-csi-driver
-    app.kubernetes.io/component: csi-driver
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: secretprovidersyncing-role
-subjects:
-- kind: ServiceAccount
-  name: secrets-store-csi-driver
-  namespace: default
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-secrets-store-provider-azure
-  namespace: cluster-baseline-settings
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/cluster-baseline-settings/flux.yaml
+++ b/cluster-baseline-settings/flux.yaml
@@ -55,7 +55,7 @@ spec:
         app.kubernetes.io/name: flux
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         agentpool: npuser01
       serviceAccountName: flux
       volumes:
@@ -141,7 +141,7 @@ spec:
         app.kubernetes.io/name: memcached
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         agentpool: npuser01
       containers:
       - name: memcached

--- a/inner-loop-scripts/azcli/cluster-deploy.azcli
+++ b/inner-loop-scripts/azcli/cluster-deploy.azcli
@@ -21,8 +21,8 @@ az acr import --source docker.io/library/memcached:1.5.20 -n $ACR_NAME && \
 az acr import --source docker.io/fluxcd/flux:1.19.0 -n $ACR_NAME && \
 az acr import --source docker.io/weaveworks/kured:1.4.0 -n $ACR_NAME && \
 az acr import --source quay.io/k8scsi/csi-node-driver-registrar:v1.2.0 -n $ACR_NAME && \
-az acr import --source docker.io/deislabs/secrets-store-csi:v0.0.11 -n $ACR_NAME && \
-az acr import --source quay.io/k8scsi/livenessprobe:v1.1.0 -n $ACR_NAME
+az acr import --source us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16 -n $ACR_NAME && \
+az acr import --source quay.io/k8scsi/livenessprobe:v2.0.0 -n $ACR_NAME
 
 # Finally the app team wants to import a wildcard certificate *.aks-ingress.contoso.com to AzureKeyVault
 # A while later this certificate is going to be the one served by a Traefik Ingress Controller wich is


### PR DESCRIPTION
* Updated to latest CSI Secret Store (v11 -> v16)
* Updated to latest Key Vault provider (v6 -> v9)
* Applied missing resource limits
* Updated `beta.kubernetes.io/os` to `kubernetes.io/os` as the former is deprecated.

Tested end to end with both public and private registries.

Closes #95 