### PR TITLE
AAD Pod Identity 1.7.0

### DIFF
--- a/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
+++ b/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
@@ -210,9 +210,12 @@ spec:
           path: /run/xtables.lock
           type: FileOrCreate
         name: iptableslock
+	    - hostPath:
+          path: /etc/default/kubelet
+        name: kubelet-config
       containers:
       - name: nmi
-        image: "mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.6.3"
+        image: "mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.7.0"
         imagePullPolicy: Always
         args:
           - "--node=$(NODE_NAME)"
@@ -223,12 +226,16 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         securityContext:
+	        runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
         volumeMounts:
         - mountPath: /run/xtables.lock
           name: iptableslock
+	      - mountPath: /etc/default/kubelet
+          name: kubelet-config
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -274,11 +281,13 @@ spec:
       serviceAccountName: aad-pod-identity-mic
       containers:
       - name: mic
-        image: "mcr.microsoft.com/oss/azure/aad-pod-identity/mic:v1.6.3"
+	      image: "mcr.microsoft.com/oss/azure/aad-pod-identity/mic:v1.7.0"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
+	      securityContext:
+          runAsUser: 0
         env:
         - name: MIC_POD_NAMESPACE
           valueFrom:

--- a/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
+++ b/cluster-baseline-settings/aad-pod-identity/aad-pod-identity.yaml
@@ -210,7 +210,7 @@ spec:
           path: /run/xtables.lock
           type: FileOrCreate
         name: iptableslock
-	    - hostPath:
+      - hostPath:
           path: /etc/default/kubelet
         name: kubelet-config
       containers:
@@ -226,14 +226,14 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         securityContext:
-	        runAsUser: 0
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
         volumeMounts:
         - mountPath: /run/xtables.lock
           name: iptableslock
-	      - mountPath: /etc/default/kubelet
+        - mountPath: /etc/default/kubelet
           name: kubelet-config
           readOnly: true
         livenessProbe:
@@ -281,12 +281,12 @@ spec:
       serviceAccountName: aad-pod-identity-mic
       containers:
       - name: mic
-	      image: "mcr.microsoft.com/oss/azure/aad-pod-identity/mic:v1.7.0"
+        image: "mcr.microsoft.com/oss/azure/aad-pod-identity/mic:v1.7.0"
         imagePullPolicy: Always
         args:
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
-	      securityContext:
+        securityContext:
           runAsUser: 0
         env:
         - name: MIC_POD_NAMESPACE


### PR DESCRIPTION
This update
* brings the bits to 1.7.0
* declairs the runAsUser to appease CIS benchmark scanning tools -- matches already existing requirement (both run as root already as one interfaces with `iptables` and the other interfaces with `/etc/kubernetes/azure.json`)
* new kubelet-config mount necessary since kubenet and AAD Pod Identity interactions are a bit different now.

I've tested an end to end run of this.

Fixes #113 
