### PR TITLE
Temporarily disable auto metric alert creation

### DIFF
--- a/10-validation.md
+++ b/10-validation.md
@@ -118,11 +118,11 @@ An [Azure Advisor Alert](https://docs.microsoft.com/azure/advisor/advisor-overvi
 1. Select _Alerts_, then _Manage Rule Alerts_.
 1. There is an alert called "AllAzureAdvisorAlert" that will be triggered based on new Azure Advisor alerts.
 
-A series of metric alerts were configured as well in this reference implementation.
+A series of metric alerts can be configured as well in this reference implementation.
 
 1. In the Azure Portal, navigate to your AKS cluster resource group (`rg-bu0001a0008`).
 1. Select your cluster, then _Insights_.
-1. Select _Recommended alerts_ to see those enabled. (Feel free to enable/disable as you see fit.)
+1. Select _Recommended alerts_ and enable those that you wish to configure.
 
 ## Validate Azure Container Registry Image Pulls
 

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -976,6 +976,99 @@
             }
         },
         {
+            "condition": false,
+            "type": "Microsoft.Insights/metricAlerts",
+            "location": "global",
+            "apiVersion": "2018-03-01",
+            "name": "[concat('Node CPU utilization high for ', variables('clusterName'), ' CI-1')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]",
+                "[resourceId('Microsoft.OperationsManagement/solutions',variables('containerInsightsSolutionName'))]"
+            ],
+            "properties": {
+                "actions": [],
+                "criteria": {
+                    "allOf": [
+                        {
+                            "criterionType": "StaticThresholdCriterion",
+                            "dimensions": [
+                                {
+                                    "name": "host",
+                                    "operator": "Include",
+                                    "values": [
+                                        "*"
+                                    ]
+                                }
+                            ],
+                            "metricName": "cpuUsagePercentage",
+                            "metricNamespace": "Insights.Container/nodes",
+                            "name": "Metric1",
+                            "operator": "GreaterThan",
+                            "threshold": 80.0,
+                            "timeAggregation": "Average"
+                        }
+                    ],
+                    "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                },
+                "description": "Node CPU utilization across the cluster.",
+                "enabled": true,
+                "evaluationFrequency": "PT1M",
+                "scopes": [
+                    "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"
+                ],
+                "severity": 3,
+                "targetResourceType": "microsoft.containerservice/managedclusters",
+                "windowSize": "PT5M"
+            }
+        },
+        {
+            "condition": false,
+            "type": "Microsoft.Insights/metricAlerts",
+            "location": "global",
+            "apiVersion": "2018-03-01",
+            "name": "[concat('Node working set memory utilization high for ', variables('clusterName'), ' CI-2')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]",
+                "[resourceId('Microsoft.OperationsManagement/solutions',variables('containerInsightsSolutionName'))]"
+            ],
+            "properties": {
+                "actions": [],
+                "criteria": {
+                    "allOf": [
+                        {
+                            "criterionType": "StaticThresholdCriterion",
+                            "dimensions": [
+                                {
+                                    "name": "host",
+                                    "operator": "Include",
+                                    "values": [
+                                        "*"
+                                    ]
+                                }
+                            ],
+                            "metricName": "memoryWorkingSetPercentage",
+                            "metricNamespace": "Insights.Container/nodes",
+                            "name": "Metric1",
+                            "operator": "GreaterThan",
+                            "threshold": 80.0,
+                            "timeAggregation": "Average"
+                        }
+                    ],
+                    "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                },
+                "description": "Node working set memory utilization across the cluster.",
+                "enabled": true,
+                "evaluationFrequency": "PT1M",
+                "scopes": [
+                    "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"
+                ],
+                "severity": 3,
+                "targetResourceType": "microsoft.containerservice/managedclusters",
+                "windowSize": "PT5M"
+            }
+        },
+        {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1028,6 +1121,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1080,6 +1174,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1132,6 +1227,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1177,6 +1273,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1229,6 +1326,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1274,6 +1372,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1326,6 +1425,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1378,6 +1478,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1430,6 +1531,7 @@
             }
         },
         {
+            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",


### PR DESCRIPTION
Due to feedback from customers and internal MSFT employees, there appears to be a race condition between cluster creation and these metric alerts being able to be created, which causes failures with random ones.  For now disable them.  I'm going to meet with the PG on these and see if there is a better solution than having this happen "minutes" after cluster creation.  Also added the other two back in that I had removed for the same reason (node CPU and node Memory -- both at 80% over 5 minutes -- default values).

I think the reason I didn't run into this in all my end-to-end testing was when I was stopped by the race condition, the time took to fix the problem (removing the items) caused enough time for the rest of the metric namespace additions to propagate.

Context: #122 and #117 