### PR TITLE
Reenable the OOTB Metric Alerts

### DIFF
--- a/10-validation.md
+++ b/10-validation.md
@@ -118,11 +118,11 @@ An [Azure Advisor Alert](https://docs.microsoft.com/azure/advisor/advisor-overvi
 1. Select _Alerts_, then _Manage Rule Alerts_.
 1. There is an alert called "AllAzureAdvisorAlert" that will be triggered based on new Azure Advisor alerts.
 
-A series of metric alerts can be configured as well in this reference implementation.
+A series of metric alerts were configured as well in this reference implementation.
 
 1. In the Azure Portal, navigate to your AKS cluster resource group (`rg-bu0001a0008`).
 1. Select your cluster, then _Insights_.
-1. Select _Recommended alerts_ and enable those that you wish to configure.
+1. Select _Recommended alerts_ to see those enabled. (Feel free to enable/disable as you see fit.)
 
 ## Validate Azure Container Registry Image Pulls
 

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -976,7 +976,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1005,7 +1004,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 80.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1022,7 +1022,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1051,7 +1050,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 80.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1068,7 +1068,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1104,7 +1103,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 0.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1121,7 +1121,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1157,7 +1156,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 90.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1174,7 +1174,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1210,7 +1209,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 90.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1227,7 +1227,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1256,7 +1255,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 0.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1273,7 +1273,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1309,7 +1308,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 80.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1326,7 +1326,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1355,7 +1354,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 0.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1372,7 +1372,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1408,7 +1407,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 0.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1425,7 +1425,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1461,13 +1460,14 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 80.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
                 },
                 "description": "This alert monitors persistent volume utilization.",
-                "enabled": true,
+                "enabled": false,
                 "evaluationFrequency": "PT1M",
                 "scopes": [
                     "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"
@@ -1478,7 +1478,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1514,7 +1513,8 @@
                             "name": "Metric1",
                             "operator": "LessThan",
                             "threshold": 80.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
@@ -1531,7 +1531,6 @@
             }
         },
         {
-            "condition": false,
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
@@ -1567,7 +1566,8 @@
                             "name": "Metric1",
                             "operator": "GreaterThan",
                             "threshold": 0.0,
-                            "timeAggregation": "Average"
+                            "timeAggregation": "Average",
+                            "skipMetricValidation": true
                         }
                     ],
                     "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"


### PR DESCRIPTION
Pass along a "skipMetricValidation" request with the resources, this allows the metric alert to be created without forcing the user to wait for the metric to exist.

Also disabled the PV alert as... since we don't have PV, it's not cost effective to enable it and shows selective usage of alerts based on the shape/needs of the cluster.