### PR TITLE
Update to 0.0.10 AKV-CSI

### DIFF
--- a/06-gitops.md
+++ b/06-gitops.md
@@ -66,9 +66,6 @@ GitOps allows a team to author Kubernetes manifest files, persist them in their 
    az acr import --source docker.io/library/memcached:1.5.20 -n $ACR_NAME
    az acr import --source docker.io/fluxcd/flux:1.19.0 -n $ACR_NAME
    az acr import --source docker.io/weaveworks/kured:1.4.0 -n $ACR_NAME
-   az acr import --source quay.io/k8scsi/csi-node-driver-registrar:v1.2.0 -n $ACR_NAME
-   az acr import --source us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16 -n $ACR_NAME
-   az acr import --source quay.io/k8scsi/livenessprobe:v2.0.0 -n $ACR_NAME
    ```
 
 1. Deploy Flux.
@@ -76,10 +73,9 @@ GitOps allows a team to author Kubernetes manifest files, persist them in their 
    > If you used your own fork of this GitHub repo, update the [`flux.yaml`](./cluster-baseline-settings/flux.yaml) file to include reference to your own repo and change the URL below to point to yours as well. Also, since Flux will begin processing the manifests in [`cluster-baseline-settings/`](./cluster-baseline-settings/) now would be a good time to:
    >
    > * update the `<replace-with-an-aad-group-object-id-for-this-cluster-role-binding>` placeholder in [`user-facing-cluster-role-aad-group.yaml`](./cluster-baseline-settings/user-facing-cluster-role-aad-group.yaml) with the Object IDs for the Azure AD group(s) you created for management purposes. If you don't, the manifest will still apply, but AAD integration will not be mapped to your specific AAD configuration.
-   > * Update six `image` manifest references to your container registry instead of the default public container registry. See comment in each file for instructions.
+   > * Update three `image` manifest references to your container registry instead of the default public container registry. See comment in each file for instructions.
    >   * update the two `image:` values in [`flux.yaml`](./cluster-baseline-settings/flux.yaml).
    >   * update the one `image:` values in [`kured-1.4.0-dockerhub.yaml`](./cluster-baseline-settings/kured-1.4.0-dockerhub.yaml).
-   >   * update the three `image:` values in [`akv-secrets-store-csi.yaml`](./cluster-baseline-settings/akv-secrets-store-csi.yaml).
 
    :warning: Deploying the flux configuration using the `flux.yaml` file unmodified from this repo will be deploying your cluster to take dependencies on public container registries. This is generally okay for exploratory/testing, but not suitable for production. Before going to production, ensure _all_ image references are from _your_ container registry (as imported in the prior step) or another that you feel confident relying on.
 

--- a/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -123,7 +123,7 @@ subjects:
   name: secrets-store-csi-driver
   namespace: cluster-baseline-settings
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.io
@@ -341,26 +341,11 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          # PRODUCTION READINESS CHANGE REQUIRED
-          # This image should be sourced from a non-public container registry, such as the
-          # one deployed along side of this reference implementation.
-          # az acr import --source quay.io/k8scsi/csi-node-driver-registrar:v1.2.0 -n <your-acr-instance-name>
-          # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/k8scsi/csi-node-driver-registrar:v1.2.0
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.0.1
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-secrets-store/csi.sock
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  [
-                    "/bin/sh",
-                    "-c",
-                    "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
-                  ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -381,13 +366,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: secrets-store
-          # PRODUCTION READINESS CHANGE REQUIRED
-          # This image should be sourced from a non-public container registry, such as the
-          # one deployed along side of this reference implementation.
-          # az acr import --source us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16 -n <your-acr-instance-name>
-          # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16
-          image: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.16
+          image: mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.17
           args:
             - "--debug=false"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -436,13 +415,7 @@ spec:
               cpu: 50m
               memory: 100Mi
         - name: liveness-probe
-          # PRODUCTION READINESS CHANGE REQUIRED
-          # This image should be sourced from a non-public container registry, such as the
-          # one deployed along side of this reference implementation.
-          # az acr import --source quay.io/k8scsi/livenessprobe:v2.0.0 -n <your-acr-instance-name>
-          # and then set this to
-          # image: <your-acr-instance-name>.azurecr.io/k8scsi/livenessprobe:v2.0.0
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.1.0
           imagePullPolicy: Always
           args:
           - --csi-address=/csi/csi.sock
@@ -503,7 +476,7 @@ spec:
       hostNetwork: true
       containers:
         - name: provider-azure-installer
-          image: mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.9
+          image: mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.10
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=unix:///provider/azure.sock
@@ -524,9 +497,7 @@ spec:
               name: providervol
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
-              mountPropagation: Bidirectional
-          securityContext:
-            privileged: true
+              mountPropagation: HostToContainer
       volumes:
         - name: providervol
           hostPath:


### PR DESCRIPTION
* Update to latest version of AKV-CSI Integration
* Update storage driver API to remove deprecation warning
* Grab container images from MCR for AKV so we don't need to import them.
* Lifecycle for registrar is removed -- new image is distroless (which means it doesn't have a shell) and now this is handled in the container via other means
* `privileged` now `false` with the new `mountPropagation`.