### PR TITLE
Remove unused NTP network rule & CSE hackathon feedback

### DIFF
--- a/02-ca-certificates.md
+++ b/02-ca-certificates.md
@@ -19,7 +19,7 @@ Now that you have the [prerequisites](./01-prerequisites.md) met, follow the ste
 
 1. Base64 encode the client-facing certificate
 
-   :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the certificate (as `.pfx`) to be base 64 encoded for proper storage in Key Vault later.
+   :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the certificate (as `.pfx`) to be Base64 encoded for proper storage in Key Vault later.
 
    ```bash
    export APP_GATEWAY_LISTENER_CERTIFICATE=$(cat appgw.pfx | base64 | tr -d '\n')
@@ -35,7 +35,7 @@ Now that you have the [prerequisites](./01-prerequisites.md) met, follow the ste
 
 1. Base64 encode the AKS Ingress Controller certificate
 
-   :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the public certificate (as `.crt` or `.cer`) to be base 64 encoded for proper storage in Key Vault later.
+   :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the public certificate (as `.crt` or `.cer`) to be Base64 encoded for proper storage in Key Vault later.
 
    ```bash
    export AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64=$(cat traefik-ingress-internal-aks-ingress-contoso-com-tls.crt | base64 | tr -d '\n')

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -36,7 +36,7 @@
         "aksIngressControllerCertificate": {
             "type": "string",
             "metadata": {
-                "description": "The base 64 encoded AKS Ingress Controller public certificate (as .crt or .cer) to be stored in Azure Key Vault as secret and referenced by Azure Application Gateway as a trusted root certificate."
+                "description": "The Base64 encoded AKS Ingress Controller public certificate (as .crt or .cer) to be stored in Azure Key Vault as secret and referenced by Azure Application Gateway as a trusted root certificate."
             }
         },
         "clusterAuthorizedIPRanges": {
@@ -129,7 +129,6 @@
         "vnetIngressServicesSubnetResourceId": "[concat(parameters('targetVnetResourceId'), '/subnets/snet-cluster-ingressservices')]",
 
         "agwName": "[concat('apw-', variables('clusterName'))]",
-        "apwResourceId": "[resourceId('Microsoft.Network/applicationGateways', variables('agwName'))]",
 
         "acrPrivateDnsZonesName": "privatelink.azurecr.io",
         "akvPrivateDnsZonesName": "privatelink.vaultcore.azure.net",
@@ -495,23 +494,26 @@
                 ],
                 "frontendPorts": [
                     {
-                        "name": "apw-frontend-ports",
+                        "name": "port-443",
                         "properties": {
                             "port": 443
                         }
                     }
                 ],
                 "autoscaleConfiguration": {
-                    "minCapacity": 0,
+                    "minCapacity": 2,
                     "maxCapacity": 10
                 },
                 "webApplicationFirewallConfiguration": {
                     "enabled": true,
                     "firewallMode": "Prevention",
                     "ruleSetType": "OWASP",
-                    "ruleSetVersion": "3.0"
+                    "ruleSetVersion": "3.2",
+                    "exclusions": [],
+                    "fileUploadLimitInMb": 10,
+                    "disabledRuleGroups": []
                 },
-                "enableHttp2": false,
+                "enableHttp2": true,
                 "sslCertificates": [
                     {
                         "name": "[concat(variables('agwName'), '-ssl-certificate')]",
@@ -558,11 +560,11 @@
                             "pickHostNameFromBackendAddress": true,
                             "requestTimeout": 20,
                             "probe": {
-                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('agwName')), '/probes/probe-bu0001a0008-00.aks-ingress.contoso.com')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/probes', variables('agwName'), 'probe-bu0001a0008-00.aks-ingress.contoso.com')]"
                             },
                             "trustedRootCertificates": [
                                 {
-                                    "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('agwName')), '/trustedRootCertificates/root-cert-wildcard-aks-ingress-contoso')]"
+                                    "id": "[resourceId('Microsoft.Network/applicationGateways/trustedRootCertificates', variables('agwName'), 'root-cert-wildcard-aks-ingress-contoso')]"
                                 }
                             ]
                         }
@@ -573,18 +575,17 @@
                         "name": "listener-https",
                         "properties": {
                             "frontendIPConfiguration": {
-                                "id": "[concat(variables('apwResourceId'), '/frontendIPConfigurations/apw-frontend-ip-configuration')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/frontendIPConfigurations', variables('agwName'), 'apw-frontend-ip-configuration')]"
                             },
                             "frontendPort": {
-                                "id": "[concat(variables('apwResourceId'), '/frontendPorts/apw-frontend-ports')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/frontendPorts', variables('agwName'), 'port-443')]"
                             },
                             "protocol": "Https",
                             "sslCertificate": {
-                                "id": "[concat(variables('apwResourceId'), '/sslCertificates/', variables('agwName'), '-ssl-certificate')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/sslCertificates', variables('agwName'),  concat(variables('agwName'), '-ssl-certificate'))]"
                             },
                             "hostName": "bicycle.contoso.com",
-                            "hostNames": [
-                            ],
+                            "hostNames": [],
                             "requireServerNameIndication": true
                         }
                     }
@@ -595,13 +596,13 @@
                         "properties": {
                             "RuleType": "Basic",
                             "httpListener": {
-                                "id": "[concat(variables('apwResourceId'), '/httpListeners/listener-https')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', variables('agwName'), 'listener-https')]"
                             },
                             "backendAddressPool": {
-                                "id": "[concat(variables('apwResourceId'), '/backendAddressPools/bu0001a0008-00.aks-ingress.contoso.com')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/backendAddressPools', variables('agwName'), 'bu0001a0008-00.aks-ingress.contoso.com')]"
                             },
                             "backendHttpSettings": {
-                                "id": "[concat(variables('apwResourceId'), '/backendHttpSettingsCollection/aks-ingress-contoso-backendpool-httpsettings')]"
+                                "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('agwName'), 'aks-ingress-contoso-backendpool-httpsettings')]"
                             }
                         }
                     }
@@ -611,7 +612,7 @@
                 {
                     "type": "providers/diagnosticSettings",
                     "apiVersion": "2017-05-01-preview",
-                    "name": "/Microsoft.Insights/default",
+                    "name": "Microsoft.Insights/default",
                     "dependsOn": [
                         "[resourceId('Microsoft.Network/applicationGateways', variables('agwName'))]",
                         "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]"

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -513,7 +513,7 @@
                     "fileUploadLimitInMb": 10,
                     "disabledRuleGroups": []
                 },
-                "enableHttp2": true,
+                "enableHttp2": false,
                 "sslCertificates": [
                     {
                         "name": "[concat(variables('agwName'), '-ssl-certificate')]",

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -501,7 +501,7 @@
                     }
                 ],
                 "autoscaleConfiguration": {
-                    "minCapacity": 2,
+                    "minCapacity": 0,
                     "maxCapacity": 10
                 },
                 "webApplicationFirewallConfiguration": {

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -21,7 +21,7 @@
 # 3. Create the following secrets in your GitHub repository:
 #    - AZURE_CREDENTIALS                         The Azure Service Principal that will deploy the AKS cluster in your Azure subscription. For more information please take a look at https://github.com/Azure/login#configure-deployment-credentials
 #    - APP_GATEWAY_LISTENER_CERTIFICATE_BASE64   The certificate data for app gateway TLS termination. It is base64. Ideally fetch this secret from a platform-managed secret store such as Azure KeyVault: https://github.com/marketplace/actions/azure-key-vault-get-secrets
-#    - AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64 The base 64 encoded AKS Ingress Controller public certificate (as .crt or .cer) to be stored in Azure Key Vault as secret and referenced by Azure Application Gateway as a trusted root certificate.
+#    - AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64 The Base64 encoded AKS Ingress Controller public certificate (as .crt or .cer) to be stored in Azure Key Vault as secret and referenced by Azure Application Gateway as a trusted root certificate.
 
 name: Deploy AKS Secure Baseline cluster stamp and Flux
 

--- a/networking/hub-regionA.json
+++ b/networking/hub-regionA.json
@@ -667,25 +667,6 @@
                                 "rules": [
                                     {
                                         "ruleType": "NetworkRule",
-                                        "name": "ntp",
-                                        "ipProtocols": [
-                                            "UDP"
-                                        ],
-                                        "sourceAddresses": [],
-                                        "sourceIpGroups": [
-                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                        ],
-                                        "destinationAddresses": [
-                                            "*"
-                                        ],
-                                        "destinationIpGroups": [],
-                                        "destinationFqdns": [],
-                                        "destinationPorts": [
-                                            "123"
-                                        ]
-                                    },
-                                    {
-                                        "ruleType": "NetworkRule",
                                         "name": "pod-to-api-server",
                                         "ipProtocols": [
                                             "TCP"
@@ -695,6 +676,7 @@
                                             "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
                                         ],
                                         "destinationAddresses": [
+                                            // You can specifically list your AKS server endpoints in appliction rules, instead of this wide-ranged rule
                                             "[concat('AzureCloud.', parameters('location'))]"
                                         ],
                                         "destinationIpGroups": [],


### PR DESCRIPTION
* Remove the firewall rule for NTP as chrony is now used (instead of ntpd) which gets time from hosts. Firewall rule no longer needed.
* Feedback from CSE hackathon
  * Use `resourceId()` instead of `concat()` in App GW
  * Updated to OWASP 3.2
  * Fixed poor naming of the 443 port in App GW
* "base 64" -> "Base64"

Completed an end-to-end deployment.