### PR TITLE
move pdb to v1 now that it's GA in 1.21

### DIFF
--- a/workload/aspnetapp.yaml
+++ b/workload/aspnetapp.yaml
@@ -68,7 +68,7 @@ spec:
       nodeSelector:
        agentpool: npuser01
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: aspnetapp-pdb


### PR DESCRIPTION
1.21 PodDisruptionBudgets are GA, spec hasn't changed, so remove the beta from the API version to reduce a warning