### PR TITLE
Add more details about the warning and the test being performed

### DIFF
--- a/04-networking.md
+++ b/04-networking.md
@@ -94,7 +94,7 @@ The following two resource groups will be created and populated with networking 
    ```bash
    RESOURCEID_SUBNET_NODEPOOLS=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0008 --query properties.outputs.nodepoolSubnetResourceIds.value -o tsv)
 
-   # [This takes about three minutes to run.]
+   # [This takes about seven minutes to run.]
    az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-regionA.json -p location=eastus2 nodepoolSubnetResourceIds="['${RESOURCEID_SUBNET_NODEPOOLS}']"
    ```
 

--- a/09-workload.md
+++ b/09-workload.md
@@ -28,17 +28,23 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
    kubectl get ingress aspnetapp-ingress -n a0008
    ```
 
-   > At this point, the route to the workload is established, SSL offloading configured, and a network policy is in place to only allow Traefik to connect to your workload. Therefore, you should expect a `403` HTTP response if you attempt to connect to it directly.
+   > At this point, the route to the workload is established, SSL offloading configured, a network policy is in place to only only allow Traefik to connect to your workload, and Traefik is configured to only accept requests from App Gateway.
 
-1. Give it a try and see a `403` HTTP response.
+1. Give it a try and see a `403` HTTP response from Traefik.
+
+   > You should expect a `403` HTTP response if you attempt to connect to the ingress controller _without_ going through the App Gateway. Likewise, if any workload other than the ingress controller attempts to reach the workload, the traffic will be denied via network policies.
 
    ```bash
    kubectl run curl -n a0008 -i --tty --rm --image=mcr.microsoft.com/azure-cli --limits='cpu=200m,memory=128Mi'
    
-   # From within the open shell
+   # From within the open shell now running on a container inside your cluster
    curl -kI https://bu0001a0008-00.aks-ingress.contoso.com -w '%{remote_ip}\n'
    exit
    ```
+
+   > :info: You might receive a message about `--limits` being deprecated, you can safely ignore that message. Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
+
+   > From this container shell, you could also try to directly acess the workload via `curl -I http://<aspnetapp-service-cluster-ip>`. Instead of getting back a `200 OK`, you'll receive a network timeout because of the [`allow-only-ingress-to-workload` network policy](./cluster-manifests/a0008/ingress-network-policy.yaml) that is in place.   
 
 ### Next step
 

--- a/09-workload.md
+++ b/09-workload.md
@@ -28,7 +28,7 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
    kubectl get ingress aspnetapp-ingress -n a0008
    ```
 
-   > At this point, the route to the workload is established, SSL offloading configured, a network policy is in place to only only allow Traefik to connect to your workload, and Traefik is configured to only accept requests from App Gateway.
+   > At this point, the route to the workload is established, SSL offloading configured, a network policy is in place to only allow Traefik to connect to your workload, and Traefik is configured to only accept requests from App Gateway.
 
 1. Give it a try and see a `403` HTTP response from Traefik.
 
@@ -44,7 +44,7 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
 
    > :beetle: You might receive a message about `--limits` being deprecated, you can [safely ignore that message](https://github.com/kubernetes/kubectl/issues/1101). Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
 
-   > From this container shell, you could also try to directly acess the workload via `curl -I http://<aspnetapp-service-cluster-ip>`. Instead of getting back a `200 OK`, you'll receive a network timeout because of the [`allow-only-ingress-to-workload` network policy](./cluster-manifests/a0008/ingress-network-policy.yaml) that is in place.   
+   > From this container shell, you could also try to directly access the workload via `curl -I http://<aspnetapp-service-cluster-ip>`. Instead of getting back a `200 OK`, you'll receive a network timeout because of the [`allow-only-ingress-to-workload` network policy](./cluster-manifests/a0008/ingress-network-policy.yaml) that is in place.   
 
 ### Next step
 

--- a/09-workload.md
+++ b/09-workload.md
@@ -42,7 +42,7 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
    exit
    ```
 
-   > :hammer: You might receive a message about `--limits` being deprecated, you can [safely ignore that message](kubernetes/kubectl#1101). Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
+   > :beetle: You might receive a message about `--limits` being deprecated, you can [safely ignore that message](https://github.com/kubernetes/kubectl/issues/1101). Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
 
    > From this container shell, you could also try to directly acess the workload via `curl -I http://<aspnetapp-service-cluster-ip>`. Instead of getting back a `200 OK`, you'll receive a network timeout because of the [`allow-only-ingress-to-workload` network policy](./cluster-manifests/a0008/ingress-network-policy.yaml) that is in place.   
 

--- a/09-workload.md
+++ b/09-workload.md
@@ -42,7 +42,7 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
    exit
    ```
 
-   > :hammer: You might receive a message about `--limits` being deprecated, you can [safely ignore that message](kubernetes/kubectl/issues#1101). Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
+   > :hammer: You might receive a message about `--limits` being deprecated, you can [safely ignore that message](kubernetes/kubectl#1101). Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
 
    > From this container shell, you could also try to directly acess the workload via `curl -I http://<aspnetapp-service-cluster-ip>`. Instead of getting back a `200 OK`, you'll receive a network timeout because of the [`allow-only-ingress-to-workload` network policy](./cluster-manifests/a0008/ingress-network-policy.yaml) that is in place.   
 

--- a/09-workload.md
+++ b/09-workload.md
@@ -42,7 +42,7 @@ The cluster now has an [Traefik configured with a TLS certificate](./08-secret-m
    exit
    ```
 
-   > :info: You might receive a message about `--limits` being deprecated, you can safely ignore that message. Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
+   > :hammer: You might receive a message about `--limits` being deprecated, you can [safely ignore that message](kubernetes/kubectl/issues#1101). Limits are still be honored; and in this deployment are required via Azure Policy for all pods running in your cluster.
 
    > From this container shell, you could also try to directly acess the workload via `curl -I http://<aspnetapp-service-cluster-ip>`. Instead of getting back a `200 OK`, you'll receive a network timeout because of the [`allow-only-ingress-to-workload` network policy](./cluster-manifests/a0008/ingress-network-policy.yaml) that is in place.   
 


### PR DESCRIPTION
* Be more clear about the intent of the `403` test
* Add an additional test they could perform as well.
* Update the time it takes to run the network update (longer now with firewall policies in place)
* Add a hint about the deprecation warning
  * I've opened a bug upstream about this kubernetes/kubectl#1101