### PR TITLE
Support MSDN and AAD guest accounts better

### DIFF
--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -14,7 +14,7 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrappi
 
    ```bash
    KEYVAULT_NAME=$(az deployment group show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.keyVaultName.value -o tsv)
-   az keyvault set-policy --certificate-permissions import list get --upn $(az account show --query user.name -o tsv) -n $KEYVAULT_NAME
+   az keyvault set-policy --certificate-permissions import list get --upn $(az ad signed-in-user show --query 'userPrincipalName' -o tsv) -n $KEYVAULT_NAME
    ```
 
 1. Import the AKS Ingress Controller's Wildcard Certificate for `*.aks-ingress.contoso.com`.
@@ -33,7 +33,7 @@ The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrappi
    > The Azure Key Vault Policy for your user was a temporary policy to allow you to upload the certificate for this walkthrough. In actual deployments, you would manage these access policies via your ARM templates using [Azure RBAC for Key Vault data plane](https://docs.microsoft.com/azure/key-vault/general/secure-your-key-vault#data-plane-and-access-policies).
 
    ```bash
-   az keyvault delete-policy --upn $(az account show --query user.name -o tsv) -n $KEYVAULT_NAME
+   az keyvault delete-policy --upn $(az ad signed-in-user show --query 'userPrincipalName' -o tsv) -n $KEYVAULT_NAME
    ```
 
 ## Check Azure Policies are in place


### PR DESCRIPTION
The AKV step sourced the domain information in such a way that it only worked for org users, but didn't work for org guests nor typical MSDN ("EXT") users.  Change how that is done to make it easier for users to get past that step.

Tested functioning on both org and MSDN accounts.