### PR TITLE
Change approach to getting AKS_CLUSTER_NAME

### DIFF
--- a/06-gitops.md
+++ b/06-gitops.md
@@ -21,7 +21,7 @@ GitOps allows a team to author Kubernetes manifest files, persist them in their 
 1. Get the cluster name.
 
    ```bash
-   AKS_CLUSTER_NAME=$(az deployment group show -g rg-bu0001a0008 -n cluster-stamp --query properties.outputs.aksClusterName.value -o tsv)
+   AKS_CLUSTER_NAME=$(az aks list -g rg-bu0001a0008 --query '[0].name' -o tsv)
    ```
 
 1. Get AKS `kubectl` credentials.


### PR DESCRIPTION
I had an issue where my deployment failed, so getting the deployment values didn't work.  See https://github.com/mspnp/aks-secure-baseline/issues/225

Instead, I recommend getting the name of the first AKS cluster in the RG as proposed.  This still works even if the deployment fails on a non-critical resource.