### PR TITLE
Add system CriticalAddonsOnly taint back

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1062,7 +1062,10 @@
                         ],
                         "upgradeSettings": {
                             "maxSurge": "33%"
-                        }
+                        },
+                        "nodeTaints": [
+                            "CriticalAddonsOnly=true:NoSchedule"
+                        ]
                     },
                     {
                         "name": "npuser01",


### PR DESCRIPTION
This taint was removed from the system node pool before because not all the add-ons supported it.  They all do now, so adding the taint back.