### PR TITLE
Fix save env variables script to work multiple times

### DIFF
--- a/saveenv.sh
+++ b/saveenv.sh
@@ -7,7 +7,7 @@
 cat > aks_baseline.env << EOF
 #!/bin/bash
 
-$(env | sed -n "s/\(_AKS_BASELINE=\)\(.*\)/\1'\2'/p" | sort)
+$(env | sed -n "s/\(.*_AKS_BASELINE=\)\(.*\)/export \1'\2'/p" | sort)
 EOF
 
 cat aks_baseline.env


### PR DESCRIPTION
The script to save env works only the first time.

For example:
1. Create `*_AKS_BASLINE` env variables
1. Call `saveenv.sh`
1. _reset session_
1. `source aks_baseline.env`
1. `saveenv.sh`

That above results in an _empty_ `aks_baseline.env` file, because the sourced ENVs are not `export`ed.  This fixes that.