### PR TITLE
Migrate to Azure RBAC for Key Vault data plane interactions

### DIFF
--- a/03-aad.md
+++ b/03-aad.md
@@ -46,9 +46,9 @@ Following the steps below you will result in an Azure AD configuration that will
    > :book: The organization knows the value of having a break-glass admin user for their critical infrastructure. The app team requests a cluster admin user and Azure AD Admin team proceeds with the creation of the user in Azure AD.
 
    ```bash
-   export TENANTDOMAIN_K8SRBAC=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv | cut -d '@' -f 2 | sed 's/\"//')
-   export AADOBJECTNAME_USER_CLUSTERADMIN=bu0001a000800-admin
-   export AADOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${AADOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${AADOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-login --password ChangeMebu0001a0008AdminChangeMe --query objectId -o tsv)
+   TENANTDOMAIN_K8SRBAC=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv | cut -d '@' -f 2 | sed 's/\"//')
+   AADOBJECTNAME_USER_CLUSTERADMIN=bu0001a000800-admin
+   AADOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${AADOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${AADOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-login --password ChangeMebu0001a0008AdminChangeMe --query objectId -o tsv)
    ```
 
 1. Add the cluster admin user(s) to the cluster admin security group.

--- a/08-secret-management-and-ingress-controller.md
+++ b/08-secret-management-and-ingress-controller.md
@@ -7,8 +7,8 @@ Previously you have configured [workload prerequisites](./07-workload-prerequisi
 1. Get the AKS Ingress Controller Managed Identity details.
 
    ```bash
-   export TRAEFIK_USER_ASSIGNED_IDENTITY_RESOURCE_ID=$(az deployment group show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.aksIngressControllerPodManagedIdentityResourceId.value -o tsv)
-   export TRAEFIK_USER_ASSIGNED_IDENTITY_CLIENT_ID=$(az deployment group show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.aksIngressControllerPodManagedIdentityClientId.value -o tsv)
+   TRAEFIK_USER_ASSIGNED_IDENTITY_RESOURCE_ID=$(az deployment group show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.aksIngressControllerPodManagedIdentityResourceId.value -o tsv)
+   TRAEFIK_USER_ASSIGNED_IDENTITY_CLIENT_ID=$(az deployment group show --resource-group rg-bu0001a0008 -n cluster-stamp --query properties.outputs.aksIngressControllerPodManagedIdentityClientId.value -o tsv)
    ```
 
 1. Ensure Flux has created the following namespace.
@@ -100,7 +100,7 @@ Previously you have configured [workload prerequisites](./07-workload-prerequisi
 
 1. Wait for Traefik to be ready.
 
-   > During Traefik's pod creation process, AAD Pod Identity will need to retrieve token for Azure Key Vault. This process can take time to complete and it's possible for the pod volume mount to fail during this time but the volume mount will eventually succeed. For more information, please refer to the [Pod Identity documentation](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/docs/pod-identity-mode.md).
+   > During Traefik's pod creation process, AAD Pod Identity will need to retrieve a token for Azure Key Vault. This process can take time to complete and it's possible for the pod volume mount to fail during this time but the volume mount will eventually succeed. For more information, please refer to the [Pod Identity documentation](https://azure.github.io/secrets-store-csi-driver-provider-azure/configurations/identity-access-modes/pod-identity-mode/).
 
    ```bash
    kubectl wait -n a0008 --for=condition=ready pod --selector=app.kubernetes.io/name=traefik-ingress-ilb --timeout=90s

--- a/10-validation.md
+++ b/10-validation.md
@@ -14,7 +14,7 @@ This section will help you to validate the workload is exposed correctly and res
 
    ```bash
    # query the Azure Application Gateway Public Ip
-   export APPGW_PUBLIC_IP=$(az deployment group show --resource-group rg-enterprise-networking-spokes -n spoke-BU0001A0008 --query properties.outputs.appGwPublicIpAddress.value -o tsv)
+   APPGW_PUBLIC_IP=$(az deployment group show --resource-group rg-enterprise-networking-spokes -n spoke-BU0001A0008 --query properties.outputs.appGwPublicIpAddress.value -o tsv)
    ```
 
 1. Create `A` Record for DNS
@@ -25,7 +25,7 @@ This section will help you to validate the workload is exposed correctly and res
 
 1. Browse to the site (e.g. <https://bicycle.contoso.com>).
 
-   > :bulb: A TLS warning will be present due to using a self-signed certificate.
+   > :bulb: A TLS warning will be present due to using a self-signed certificate. You can ignore it or import the self-signed cert (`appgw.pfx`) to your user's trusted root store.
 
 ## Validate reader access to the a0008 namespace. _Optional._
 

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -215,7 +215,6 @@
                         }*/
                     ]
                 },
-                "publicNetworkAccess": "Enabled", // Production readiness change: This is only needed because we upload a certificate after deployment as part of the instructions. This can be set to "Disabled" for runtime.
                 "enableRbacAuthorization": true,
                 "enabledForDeployment": false,
                 "enabledForDiskEncryption": false,

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -201,7 +201,7 @@
                 },
                 "tenantId": "[subscription().tenantId]",
                 "networkAcls": {
-                    "bypass": "AzureServices", // "None", // Required for AppGW communication
+                    "bypass": "AzureServices", // Required for AppGW communication
                     "defaultAction": "Deny", // Production readiness change: This is only needed because we upload a certificate after deployment as part of the instructions. This can be set to "Deny" for runtime.
                     "ipRules": [/*
                         {
@@ -476,7 +476,9 @@
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName') )]",
-                "[resourceId('Microsoft.Network/privateEndpoints', 'nodepools-to-akv')]"
+                "[resourceId('Microsoft.Network/privateEndpoints', 'nodepools-to-akv')]",
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultReader')))]",
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultSecretsUserRole')))]"
             ],
             "identity": {
                 "type": "UserAssigned",
@@ -1064,7 +1066,9 @@
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameEnforceInternalLoadBalancers'))]",
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameEnforceResourceLimits'))]",
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameRoRootFilesystem'))]",
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
+                "[resourceId('Microsoft.Network/privateEndpoints', 'nodepools-to-akv')]",
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultReader')))]",
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultSecretsUserRole')))]"
             ],
             "properties": {
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -194,7 +194,7 @@
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'podmi-ingress-controller')]"
             ],
             "properties": {
-                "accessPolicies": [],
+                "accessPolicies": [], // Azure RBAC is used instead
                 "sku": {
                     "family": "A",
                     "name": "standard"
@@ -202,18 +202,9 @@
                 "tenantId": "[subscription().tenantId]",
                 "networkAcls": {
                     "bypass": "AzureServices", // Required for AppGW communication
-                    "defaultAction": "Deny", // Production readiness change: This is only needed because we upload a certificate after deployment as part of the instructions. This can be set to "Deny" for runtime.
-                    "ipRules": [/*
-                        {
-                            "value": "[reference(resourceId(variables('vNetResourceGroup'), 'Microsoft.Network/publicIpAddresses', 'pip-BU0001A0008-00'), '2021-02-01').ipAddress]"
-                        }*/
-                    ],
-                    "virtualNetworkRules": [/*
-                        {
-                            "id": "[concat(parameters('targetVnetResourceId'), '/subnets/snet-applicationgateway')]",
-                            "ignoreMissingVnetServiceEndpoint": true
-                        }*/
-                    ]
+                    "defaultAction": "Deny",
+                    "ipRules": [],
+                    "virtualNetworkRules": []
                 },
                 "enableRbacAuthorization": true,
                 "enabledForDeployment": false,

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -201,7 +201,7 @@
                 },
                 "tenantId": "[subscription().tenantId]",
                 "networkAcls": {
-                    "bypass": "None", // Required for AppGW communication
+                    "bypass": "AzureServices", // "None", // Required for AppGW communication
                     "defaultAction": "Deny", // Production readiness change: This is only needed because we upload a certificate after deployment as part of the instructions. This can be set to "Deny" for runtime.
                     "ipRules": [/*
                         {
@@ -225,26 +225,24 @@
             "resources": [
                 {
                     "type": "secrets",
-                    "apiVersion": "2019-09-01",
-                    "name": "sslcert",
+                    "apiVersion": "2021-06-01-preview",
+                    "name": "gateway-public-cert",
                     "dependsOn": [
                         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName') )]"
                     ],
                     "properties": {
-                        "value": "[parameters('appGatewayListenerCertificate')]",
-                        "recoveryLevel": "Purgeable"
+                        "value": "[parameters('appGatewayListenerCertificate')]"
                     }
                 },
                 {
                     "type": "secrets",
-                    "apiVersion": "2019-09-01",
+                    "apiVersion": "2021-06-01-preview",
                     "name": "appgw-ingress-internal-aks-ingress-tls",
                     "dependsOn": [
                         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
                     ],
                     "properties": {
-                        "value": "[parameters('aksIngressControllerCertificate')]",
-                        "recoveryLevel": "Purgeable"
+                        "value": "[parameters('aksIngressControllerCertificate')]"
                     }
                 },
                 {
@@ -478,7 +476,8 @@
             "name": "[variables('agwName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName') )]"
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName') )]",
+                "[resourceId('Microsoft.Network/privateEndpoints', 'nodepools-to-akv')]"
             ],
             "identity": {
                 "type": "UserAssigned",
@@ -558,7 +557,7 @@
                     {
                         "name": "[concat(variables('agwName'), '-ssl-certificate')]",
                         "properties": {
-                            "keyVaultSecretId": "[concat(reference(variables('keyVaultName')).vaultUri,'secrets/sslcert')]"
+                            "keyVaultSecretId": "[concat(reference(variables('keyVaultName')).vaultUri,'secrets/gateway-public-cert')]"
                         }
                     }
                 ],
@@ -1065,7 +1064,8 @@
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameEnforceImageSource'))]",
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameEnforceInternalLoadBalancers'))]",
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameEnforceResourceLimits'))]",
-                "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameRoRootFilesystem'))]"
+                "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameRoRootFilesystem'))]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
             ],
             "properties": {
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -118,7 +118,8 @@
         "acrPullRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
         "managedIdentityOperatorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830')]",
         "virtualMachineContributorRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
-        "readerRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+        "keyVaultReader": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/21090545-7ca7-4776-b22c-e363652d74d2')]",
+        "keyVaultSecretsUserRole": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6')]",
         "clusterAdminRoleId": "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
         "clusterReaderRoleId": "7f6c6a51-bcf8-42ba-9220-52d62157d7db",
         "serviceClusterUserRoleId": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
@@ -185,7 +186,7 @@
         },
         {
             "type": "Microsoft.KeyVault/vaults",
-            "apiVersion": "2019-09-01",
+            "apiVersion": "2021-06-01-preview",
             "name": "[variables('keyVaultName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -193,45 +194,29 @@
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'podmi-ingress-controller')]"
             ],
             "properties": {
-                "accessPolicies": [
-                    {
-                        "tenantId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'mi-appgateway-frontend')).tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'mi-appgateway-frontend')).principalId]",
-                        "permissions": {
-                            "secrets": [
-                                "get"
-                            ],
-                            "certificates": [
-                                "get"
-                            ],
-                            "keys": []
-                        }
-                    },
-                    {
-                        "tenantId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','podmi-ingress-controller')).tenantId]",
-                        "objectId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities','podmi-ingress-controller')).principalId]",
-                        "permissions": {
-                            "secrets": [
-                                "get"
-                            ],
-                            "certificates": [
-                                "get"
-                            ],
-                            "keys": []
-                        }
-                    }
-                ],
+                "accessPolicies": [],
                 "sku": {
                     "family": "A",
                     "name": "standard"
                 },
                 "tenantId": "[subscription().tenantId]",
                 "networkAcls": {
-                    "bypass": "AzureServices",
-                    "defaultAction": "Allow",
-                    "ipRules": [],
-                    "virtualNetworkRules": []
+                    "bypass": "None", // Required for AppGW communication
+                    "defaultAction": "Deny", // Production readiness change: This is only needed because we upload a certificate after deployment as part of the instructions. This can be set to "Deny" for runtime.
+                    "ipRules": [/*
+                        {
+                            "value": "[reference(resourceId(variables('vNetResourceGroup'), 'Microsoft.Network/publicIpAddresses', 'pip-BU0001A0008-00'), '2021-02-01').ipAddress]"
+                        }*/
+                    ],
+                    "virtualNetworkRules": [/*
+                        {
+                            "id": "[concat(parameters('targetVnetResourceId'), '/subnets/snet-applicationgateway')]",
+                            "ignoreMissingVnetServiceEndpoint": true
+                        }*/
+                    ]
                 },
+                "publicNetworkAccess": "Enabled", // Production readiness change: This is only needed because we upload a certificate after deployment as part of the instructions. This can be set to "Disabled" for runtime.
+                "enableRbacAuthorization": true,
                 "enabledForDeployment": false,
                 "enabledForDiskEncryption": false,
                 "enabledForTemplateDeployment": false,
@@ -289,14 +274,59 @@
                 {
                     "type": "providers/roleAssignments",
                     "apiVersion": "2018-09-01-preview",
-                    "name": "[concat('Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('readerRole')))]",
+                    "name": "[concat('Microsoft.Authorization/', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultSecretsUserRole')))]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'mi-appgateway-frontend')]"
+                    ],
+                    "comments": "Grant the Azure Application Gateway managed identity with key vault reader role permissions; this allows pulling frontend and backend certificates.",
+                    "properties": {
+                        "roleDefinitionId": "[variables('keyVaultSecretsUserRole')]",
+                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'mi-appgateway-frontend')).principalId]",
+                        "principalType": "ServicePrincipal"
+                    }
+                },
+                {
+                    "type": "providers/roleAssignments",
+                    "apiVersion": "2018-09-01-preview",
+                    "name": "[concat('Microsoft.Authorization/', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultReader')))]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'mi-appgateway-frontend')]"
+                    ],
+                    "comments": "Grant the Azure Application Gateway managed identity with key vault reader role permissions; this allows pulling frontend and backend certificates.",
+                    "properties": {
+                        "roleDefinitionId": "[variables('keyVaultReader')]",
+                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'mi-appgateway-frontend')).principalId]",
+                        "principalType": "ServicePrincipal"
+                    }
+                },
+                {
+                    "type": "providers/roleAssignments",
+                    "apiVersion": "2018-09-01-preview",
+                    "name": "[concat('Microsoft.Authorization/', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultSecretsUserRole')))]",
                     "dependsOn": [
                         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
                         "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'podmi-ingress-controller')]"
                     ],
-                    "comments": "Grant the AKS cluster ingress controller pod managed identity with reader role permissions over Key Vault; paired with the Access Policy, this allows our ingress controller to pull certificates.",
+                    "comments": "Grant the AKS cluster ingress controller pod managed identity with key vault reader role permissions; this allows our ingress controller to pull certificates.",
                     "properties": {
-                        "roleDefinitionId": "[variables('readerRole')]",
+                        "roleDefinitionId": "[variables('keyVaultSecretsUserRole')]",
+                        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'podmi-ingress-controller')).principalId]",
+                        "principalType": "ServicePrincipal"
+                    }
+                },
+                {
+                    "type": "providers/roleAssignments",
+                    "apiVersion": "2018-09-01-preview",
+                    "name": "[concat('Microsoft.Authorization/', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultReader')))]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'podmi-ingress-controller')]"
+                    ],
+                    "comments": "Grant the AKS cluster ingress controller pod managed identity with key vault reader role permissions; this allows our ingress controller to pull certificates.",
+                    "properties": {
+                        "roleDefinitionId": "[variables('keyVaultReader')]",
                         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'podmi-ingress-controller')).principalId]",
                         "principalType": "ServicePrincipal"
                     }
@@ -1945,8 +1975,8 @@
         },
         {
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities/providers/roleAssignments",
-            "name": "[concat('podmi-ingress-controller', '/Microsoft.Authorization/', guid(concat(resourceGroup().id), variables('managedIdentityOperatorRole')))]",
             "apiVersion": "2018-09-01-preview",
+            "name": "[concat('podmi-ingress-controller', '/Microsoft.Authorization/', guid(resourceGroup().id, 'podmi-ingress-controller', variables('managedIdentityOperatorRole')))]",
             "comments": "Grant the AKS cluster with Manage Identity Operator role permissions over the managed identity used for the ingress controller.  Allows it to be assigned to the underlying VMSS.",
             "dependsOn": [
                 "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -475,10 +475,10 @@
             "name": "[variables('agwName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName') )]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
                 "[resourceId('Microsoft.Network/privateEndpoints', 'nodepools-to-akv')]",
-                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultReader')))]",
-                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultSecretsUserRole')))]"
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', variables('keyVaultName'), 'Microsoft.Authorization', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultReader')))]",
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', variables('keyVaultName'), 'Microsoft.Authorization', guid(resourceGroup().id, 'mi-appgateway-frontend', variables('keyVaultSecretsUserRole')))]"
             ],
             "identity": {
                 "type": "UserAssigned",
@@ -486,11 +486,7 @@
                     "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities',  'mi-appgateway-frontend')]": {}
                 }
             },
-            "zones": [
-                "1",
-                "2",
-                "3"
-            ],
+            "zones": "[pickZones('Microsoft.Network', 'applicationGateways', parameters('location'), 3)]",
             "properties": {
                 "sku": {
                     "name": "WAF_v2",
@@ -1067,8 +1063,8 @@
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameEnforceResourceLimits'))]",
                 "[resourceId('Microsoft.Authorization/policyAssignments', variables('policyAssignmentNameRoRootFilesystem'))]",
                 "[resourceId('Microsoft.Network/privateEndpoints', 'nodepools-to-akv')]",
-                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultReader')))]",
-                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', 'Microsoft.Authorization', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultSecretsUserRole')))]"
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', variables('keyVaultName'), 'Microsoft.Authorization', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultReader')))]",
+                "[resourceId('Microsoft.KeyVault/vaults/providers/roleAssignments', variables('keyVaultName'), 'Microsoft.Authorization', guid(resourceGroup().id, 'podmi-ingress-controller', variables('keyVaultSecretsUserRole')))]"
             ],
             "properties": {
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",

--- a/networking/hub-default.json
+++ b/networking/hub-default.json
@@ -367,7 +367,7 @@
         },
         {
             "type": "Microsoft.Network/firewallPolicies",
-            "apiVersion": "2020-11-01",
+            "apiVersion": "2021-02-01",
             "name": "[variables('fwPoliciesBaseName')]",
             "location": "[parameters('location')]",
             "properties": {
@@ -386,7 +386,7 @@
             "resources": [
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesBaseName'), '/DefaultNetworkRuleCollectionGroup')]",
                     "location": "[parameters('location')]",
                     "dependsOn": [
@@ -431,7 +431,7 @@
         },
         {
             "type": "Microsoft.Network/firewallPolicies",
-            "apiVersion": "2020-11-01",
+            "apiVersion": "2021-02-01",
             "name": "[variables('fwPoliciesName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -457,7 +457,7 @@
             "resources": [
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesName'), '/DefaultDnatRuleCollectionGroup')]",
                     "location": "[parameters('location')]",
                     "dependsOn": [
@@ -470,7 +470,7 @@
                 },
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesName'), '/DefaultApplicationRuleCollectionGroup')]",
                     "location":"[parameters('location')]",
                     "dependsOn": [
@@ -484,7 +484,7 @@
                 },
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesName'), '/DefaultNetworkRuleCollectionGroup')]",
                     "location": "[parameters('location')]",
                     "dependsOn": [

--- a/networking/hub-regionA.json
+++ b/networking/hub-regionA.json
@@ -375,7 +375,7 @@
         },
         {
             "type": "Microsoft.Network/ipGroups",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2021-05-01",
             "name": "[variables('aksIpGroupName')]",
             "location": "[parameters('location')]",
             "comments": "This holds IP addresses of known nodepool subnets in spokes.",
@@ -391,9 +391,12 @@
         },
         {
             "type": "Microsoft.Network/firewallPolicies",
-            "apiVersion": "2020-11-01",
+            "apiVersion": "2021-02-01",
             "name": "[variables('fwPoliciesBaseName')]",
             "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+            ],
             "properties": {
                 "sku": {
                     "tier": "Standard"
@@ -410,7 +413,7 @@
             "resources": [
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesBaseName'), '/DefaultNetworkRuleCollectionGroup')]",
                     "location": "[parameters('location')]",
                     "dependsOn": [
@@ -455,7 +458,7 @@
         },
         {
             "type": "Microsoft.Network/firewallPolicies",
-            "apiVersion": "2020-11-01",
+            "apiVersion": "2021-02-01",
             "name": "[variables('fwPoliciesName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -481,7 +484,7 @@
             "resources": [
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesName'), '/DefaultDnatRuleCollectionGroup')]",
                     "location": "[parameters('location')]",
                     "dependsOn": [
@@ -494,7 +497,7 @@
                 },
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesName'), '/DefaultApplicationRuleCollectionGroup')]",
                     "location":"[parameters('location')]",
                     "dependsOn": [
@@ -648,7 +651,7 @@
                 },
                 {
                     "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
-                    "apiVersion": "2020-11-01",
+                    "apiVersion": "2021-02-01",
                     "name": "[concat(variables('fwPoliciesName'), '/DefaultNetworkRuleCollectionGroup')]",
                     "location": "[parameters('location')]",
                     "dependsOn": [


### PR DESCRIPTION
* Move from Access Policies to Azure RBAC for data plane interactions (Fixes: #232)
* Minor standardization tweak on usage of `export`
* Tightened up Azure Key Vault firewall a bit
* Renamed the app gateway listener SSL cert to be something a bit more descriptive in Key Vault
* Updated some `dependsOn` to include necessary role assignments
* A few RM API version updates