### PR TITLE
Update container name in sample query to match deployed container

### DIFF
--- a/10-validation.md
+++ b/10-validation.md
@@ -99,7 +99,7 @@ The example workload uses the standard dotnet logger interface, which are captur
 
    ```
    let podInventory = KubePodInventory
-   | where ContainerName endswith "aspnetcore-webapp-sample"
+   | where ContainerName endswith "aspnet-webapp-sample"
    | distinct ContainerID, ContainerName
    | project-rename Name=ContainerName;
    ContainerLog


### PR DESCRIPTION
Update example query for viewing container logs from log analytics. The deployed container name is `aspnet-webapp-sample`.
The sample query will now return data on the default setup.
Container name is set here https://github.com/mspnp/aks-secure-baseline/blob/main/workload/aspnetapp.yaml#L49