### PR TITLE
Fixed configuration error discarding forwarded headers from upstream

### DIFF
--- a/workload/traefik.yaml
+++ b/workload/traefik.yaml
@@ -132,7 +132,7 @@ data:
         address = ":9000"
       [entryPoints.websecure]
         address = ":8443"
-        [entryPoints.web.forwardedHeaders]
+        [entryPoints.websecure.forwardedHeaders]
           trustedIPs = ["10.240.4.16/28"]
         [entryPoints.websecure.http.tls]
           options = "default"


### PR DESCRIPTION
This pull request addresses what I believe to be an issue in the Traefik configuration of the AKS secure baseline.

In the configuration, when whitelisting upstream IP addresses for forwarded headers, the configuration incorrectly references the non-existent entrypoint `web`, when it should instead refer to `websecure`.

Please feel free to close this PR if I am mistaken, but we have not been able to get forwarded headers to work without changing the configuration to reference `websecure`. Specifically, when using the current configuration of the baseline, our workloads in AKS do not receive the upstream header `X-Forwarded-Host`, but when changing the configuration to `websecure`, the header is forwarded correctly.