### PR TITLE
Clarify that the nodepools are subject to the authorized IP address ranges as well

### DIFF
--- a/05-aks-cluster.md
+++ b/05-aks-cluster.md
@@ -24,7 +24,7 @@ Now that the [hub-spoke network is provisioned](./04-networking.md), the next st
    ```
 
 1. Deploy the cluster ARM template.  
-  :exclamation: By default, this deployment will allow unrestricted access to your cluster's API Server.  You can limit access to the API Server to a set of well-known IP addresses (i.,e. a jump box subnet (connected to by Azure Bastion), build agents, or any other networks you'll administer the cluster from) by setting the `clusterAuthorizedIPRanges` parameter in all deployment options.  
+  :exclamation: By default, this deployment will allow unrestricted access to your cluster's API Server. You can limit access to the API Server to a set of well-known IP addresses (i.,e. a jump box subnet (connected to by Azure Bastion), build agents, or any other networks you'll administer the cluster from) by setting the `clusterAuthorizedIPRanges` parameter in all deployment options. This setting will also impact traffic originating from within the cluster trying to use the API server, so you will also need to include _all_ of the public IPs used by your egress Azure Firewall. For more information, see [Secure access to the API server using authorized IP address ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges#create-an-aks-cluster-with-api-server-authorized-ip-ranges-enabled).
 
     **Option 1 - Deploy from the command line**
 


### PR DESCRIPTION
As suggested by @scaswell-hirez in #259, add more information about the need to ensure that the public ip addresses that API server traffic is flowing from is allowed in the authorized IP address range.