### PR TITLE
Clarify content naming

### DIFF
--- a/01-prerequisites.md
+++ b/01-prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-This is the starting point for the instructions on deploying the [AKS Secure Baseline reference implementation](./README.md). There is required access and tooling you'll need in order to accomplish this. Follow the instructions below and on the subsequent pages so that you can get your environment ready to proceed with the AKS cluster creation.
+This is the starting point for the instructions on deploying the [AKS Baseline reference implementation](./README.md). There is required access and tooling you'll need in order to accomplish this. Follow the instructions below and on the subsequent pages so that you can get your environment ready to proceed with the AKS cluster creation.
 
 ## Steps
 

--- a/04-networking.md
+++ b/04-networking.md
@@ -1,6 +1,6 @@
 # Deploy the Hub-Spoke Network Topology
 
-The prerequisites for the [AKS secure baseline cluster](./) are now completed with [Azure AD group and user work](./03-aad.md) performed in the prior steps. Now we will start with our first Azure resource deployment, the network resources.
+The prerequisites for the [AKS Baseline cluster](./) are now completed with [Azure AD group and user work](./03-aad.md) performed in the prior steps. Now we will start with our first Azure resource deployment, the network resources.
 
 ## Subscription and resource group topology
 

--- a/05-aks-cluster.md
+++ b/05-aks-cluster.md
@@ -1,6 +1,6 @@
 # Deploy the AKS Cluster
 
-Now that the [hub-spoke network is provisioned](./04-networking.md), the next step in the [AKS secure Baseline reference implementation](./) is deploying the AKS cluster and its adjacent Azure resources.
+Now that the [hub-spoke network is provisioned](./04-networking.md), the next step in the [AKS Baseline reference implementation](./) is deploying the AKS cluster and its adjacent Azure resources.
 
 ## Steps
 

--- a/07-workload-prerequisites.md
+++ b/07-workload-prerequisites.md
@@ -1,6 +1,6 @@
 # Workload Prerequisites
 
-The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrapping up the infrastructure focus of the [AKS secure Baseline reference implementation](./). Follow the steps below to import the TLS certificate that the Ingress Controller will serve for Application Gateway to connect to your web app.
+The AKS Cluster has been enrolled in [GitOps management](./06-gitops.md), wrapping up the infrastructure focus of the [AKS Baseline reference implementation](./). Follow the steps below to import the TLS certificate that the Ingress Controller will serve for Application Gateway to connect to your web app.
 
 ## Steps
 

--- a/10-validation.md
+++ b/10-validation.md
@@ -1,6 +1,6 @@
 # End-to-End Validation
 
-Now that you have a workload deployed, the [ASP.NET Core Docker sample web app](./09-workload.md), you can start validating and exploring this reference implementation of the [AKS secure baseline cluster](./). In addition to the workload, there are some observability validation you can perform as well.
+Now that you have a workload deployed, the [ASP.NET Core Docker sample web app](./09-workload.md), you can start validating and exploring this reference implementation of the [AKS Baseline cluster](./). In addition to the workload, there are some observability validation you can perform as well.
 
 ## Validate the Web App
 

--- a/11-cleanup.md
+++ b/11-cleanup.md
@@ -1,6 +1,6 @@
 # Clean up
 
-After you are done exploring your deployed [AKS secure baseline cluster](./), you'll want to delete the created Azure resources to prevent undesired costs from accruing. Follow these steps to delete all resources created as part of this reference implementation.
+After you are done exploring your deployed [AKS Baseline cluster](./), you'll want to delete the created Azure resources to prevent undesired costs from accruing. Follow these steps to delete all resources created as part of this reference implementation.
 
 ## Steps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to the AKS Secure Baseline Reference Implementation
+# Contributing to the AKS Baseline reference implementation
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com/>.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Kubernetes Service (AKS) Baseline Cluster
 
-This reference implementation demonstrates the _recommended starting (baseline) infrastructure architecture_ for a general purpose [AKS cluster](https://azure.microsoft.com/services/kubernetes-service). This implementation and document is meant to guide an interdisciplinary team or multiple distinct teams like networking, security and development through the process of getting this secure baseline infrastructure deployed and understanding the components of it.
+This reference implementation demonstrates the _recommended starting (baseline) infrastructure architecture_ for a general purpose [AKS cluster](https://azure.microsoft.com/services/kubernetes-service). This implementation and document is meant to guide an interdisciplinary team or multiple distinct teams like networking, security and development through the process of getting this general purpose baseline infrastructure deployed and understanding the components of it.
 
 We walk through the deployment here in a rather _verbose_ method to help you understand each component of this cluster, ideally teaching you about each layer and providing you with the knowledge necessary to apply it to your workload.
 

--- a/github-workflow/aks-deploy.properties.json
+++ b/github-workflow/aks-deploy.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Deploy AKS Secure Baseline cluster stamp and Flux",
+    "name": "Deploy AKS Baseline cluster stamp and Flux",
     "description": "This workflow will deploy our cluster stamp in your own vnet and also Flux",
     "creator": "Microsoft Patterns & Practices",
     "iconName": "azure",

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -23,7 +23,7 @@
 #    - APP_GATEWAY_LISTENER_CERTIFICATE_BASE64   The certificate data for app gateway TLS termination. It is base64. Ideally fetch this secret from a platform-managed secret store such as Azure KeyVault: https://github.com/marketplace/actions/azure-key-vault-get-secrets
 #    - AKS_INGRESS_CONTROLLER_CERTIFICATE_BASE64 The Base64 encoded AKS Ingress Controller public certificate (as .crt or .cer) to be stored in Azure Key Vault as secret and referenced by Azure Application Gateway as a trusted root certificate.
 
-name: Deploy AKS Secure Baseline cluster stamp and Flux
+name: Deploy AKS Baseline cluster stamp and Flux
 
 on:
   push:


### PR DESCRIPTION
The legacy naming of "secure baseline" still existed in a few places.