### PR TITLE
Fixed fluxV2 extension resource template

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1022,7 +1022,7 @@
                         "[resourceId('Microsoft.ContainerRegistry/registries/providers/roleAssignments', variables('defaultAcrName'), 'Microsoft.Authorization', guid(resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName')), variables('acrPullRole')))]"
                     ],
                     "properties": {
-                        "extensionType": "Microsoft.Flux",
+                        "extensionType": "microsoft.flux",
                         "autoUpgradeMinorVersion": true,
                         "releaseTrain": "Stable",
                         "scope": {


### PR DESCRIPTION
The "configurationSettings" and "configurationProtectedSettings" sections of "Microsoft.KubernetesConfiguration/flux" were defined in the wrong area. Corrected the sections to comply with the schema. https://docs.microsoft.com/en-us/azure/templates/microsoft.kubernetesconfiguration/extensions?tabs=json#template-format
This also fixes the issue of configurations not appearing in the AKS cluster's "GitOps" view in the Azure Portal.