### PR TITLE
feat (cluster): [aks] full cluster upgrade to 1.36.0 (control plane + all node pools)

### DIFF
--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -52,7 +52,7 @@ var aksIngressDomainName = 'aks-ingress.${domainName}'
 var aksBackendDomainName = 'bu0001a0008-00.${aksIngressDomainName}'
 var isUsingAzureRBACasKubernetesRBAC = (subscription().tenantId == k8sControlPlaneAuthorizationTenantId)
 
-var kubernetesVersion = '1.35.0'
+var kubernetesVersion = '1.36.0'
 
 /*** EXISTING SUBSCRIPTION RESOURCES ***/
 


### PR DESCRIPTION
## WHY

AKS 1.36.0 is now available (preview). Keeping the reference implementation current with the latest Kubernetes version ensures guidance stays relevant and users can validate new features early.

## WHAT Changed?

- [x] Full cluster upgrade, bumping kubernetesVersion from 1.35.0 to 1.36.0. The Bicep template applies the same version to the control plane, system node pool, and user node pool.

## TEST

### 1. Bicep compilation ✅

```
az bicep build -f <file>.bicep
```

| Template | Result |
|----------|--------|
| `workload-team/cluster-stamp.bicep` | ✅ |
| `workload-team/acr-stamp.bicep` | ✅ |
| `network-team/hub-default.bicep` | ✅ |
| `network-team/hub-regionA.bicep` | ✅ |
| `network-team/spoke-BU0001A0008.bicep` | ✅ |
| `network-team/virtualNetworkPeering.bicep` | ✅ |

### 2. Version availability ✅

Confirmed `1.36.0` (preview) is available in `francecentral`.

### 3. End-to-end deployment ✅

Full sequential deployment completed in **francecentral**:

| Step | Result |
|------|--------|
| 01 — Prerequisites | ✅ az cli 2.79.0, kubectl 1.35.3, openssl 3.0.2 |
| 02 — TLS Certificates | ✅ App Gateway + Traefik ingress certs generated |
| 03 — Microsoft Entra ID | ✅ |
| 04 — Networking | ✅ Hub + spoke + Azure Firewall deployed |
| 05 — Bootstrap Prep | ✅ ACR deployed |
| 06 — AKS Cluster | ✅ Deployed successfully |
| 07 — Bootstrap Validation | ✅ Flux bootstrapped, namespaces created |
| 08 — Workload Prerequisites | ✅ TLS cert imported to Key Vault |
| 09 — Ingress Controller | ✅ Traefik running (2 pods ready) |
| 10 — Workload | ✅ ASP.NET app deployed |
| 11 — Validation | ✅ App Gateway → Traefik → workload (HTTPS 200), Gatekeeper policy deny ✅, WAF SQL injection block (403) ✅ |

**Cluster version confirmed:**
```
Client Version: v1.35.3
Server Version: v1.36.0
```

**Node pools:**
| Pool | Count | VM Size | K8s Version |
|------|-------|---------|-------------|
| npsystem | 3 | Standard_D2d_v5 | 1.36.0 |
| npuser01 | 2 | Standard_D4d_v5 | 1.36.0 |

<img width="1846" height="1286" alt="image" src="https://github.com/user-attachments/assets/fca5642a-80f1-4c1e-a1ee-13906b20f795" />

<img width="1640" height="338" alt="image" src="https://github.com/user-attachments/assets/1cd3bdb2-9894-4ae9-8ada-f016456142b9" />

<img width="1504" height="146" alt="image" src="https://github.com/user-attachments/assets/0378d2ac-c879-4558-80a2-6ba819f88954" />

---

Co-authored-by: GitHub Copilot CLI (Claude Opus 4.6) <noreply@github.com>
