### PR TITLE
Addressing security alert

### DIFF
--- a/docs/deploy/03-microsoft-entra-id.md
+++ b/docs/deploy/03-microsoft-entra-id.md
@@ -69,7 +69,8 @@ This does not configure anything related to workload identity. This configuratio
    ```bash
    TENANTDOMAIN_K8SRBAC=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv | cut -d '@' -f 2 | sed 's/\"//')
    MEIDOBJECTNAME_USER_CLUSTERADMIN=bu0001a000800-admin
-   MEIDOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${MEIDOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${MEIDOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-sign-in --password ChangeMebu0001a0008AdminChangeMe --query id -o tsv)
+   MEIDPASS_USER_CLUSTERADMIN='<Enter a password for the break-glass admin user that meets Microsoft Entra ID password policies>'
+   MEIDOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${MEIDOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${MEIDOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-sign-in --password "${MEIDPASS_USER_CLUSTERADMIN}" --query id -o tsv)
    echo TENANTDOMAIN_K8SRBAC: $TENANTDOMAIN_K8SRBAC
    echo MEIDOBJECTNAME_USER_CLUSTERADMIN: $MEIDOBJECTNAME_USER_CLUSTERADMIN
    echo MEIDOBJECTID_USER_CLUSTERADMIN: $MEIDOBJECTID_USER_CLUSTERADMIN


### PR DESCRIPTION
## Summary

Remove hardcoded password from the break-glass admin user creation step in the Microsoft Entra ID setup documentation. This resolves secret scanning alert #2. Alert #4 referenced files that are not in the current state of the reference implementation and was closed.

The change is intentionally small because there are other open PRs, to avoid conflicts.

## What changed

The hardcoded password `ChangeMebu0001a0008AdminChangeMe` in the `az ad user create` command was replaced with a user-supplied variable `MEIDPASS_USER_CLUSTERADMIN` and a `<placeholder>` prompt, following the same convention used elsewhere in the docs (e.g., `<Replace-With-ClusterApi-EntraID-TenantId>`).